### PR TITLE
Fix/unregular boundaries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Exclude CSV files
+*.csv linguist-generated=true
+
+# Exclude Jupyter Notebook outputs
+*.ipynb linguist-generated=true
+
+# Exclude documentation files
+*.md linguist-documentation=true
+*.rst linguist-documentation=true

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 /paper/old
 .VSCodeCounter
 /test
+.mypy_cache/
+.ruff_cache/
 examples/__pycache__/
 examples/logs/
 examples/data/output/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,12 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - `align_three_point`, `align_manual` and `align_combined` are now all generic, taking either `PyGeometryPair` or `PyGeometry` as input
 - Test file added `test_intravascular.py` to demonstrate that same results with both
 
-## [0.3.3] - 2026-05-06
+## [0.3.3] - 2026-05-06 Release JOSS paper
 
 ### Added
 - `CITATION.cff` with full author list, ORCIDs, and preferred citation for JOSS/Zenodo archival.
 - Zenodo DOI badge added to README.
+- Created a release coupled to JOSS publication
 
 ## [0.3.2] - 2026-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.5] - 2026-05-15
+
+### Added
+- `clamp_overshoot` parameter in `stitch_ccta_to_intravascular` (default 0.5 mm): for anomalous
+  ostia where the boundary-ring plane and the IV plane diverge by ≥ 45°, every proximal boundary
+  point is projected onto the IV plane and then pushed at least `clamp_overshoot` mm away from it,
+  creating an inward step that softens the stitching angle.
+- `_enforce_layer_gap_from_plane`: the two mesh rings adjacent to the clamped boundary are
+  pushed radially outward within the IV plane (ring 1: 0.1 mm, ring 2: 0.2 mm) to eliminate
+  ridges at the clamping zone.
+- Tests for `_clamp_to_plane`, `_enforce_layer_gap_from_plane`, and `_prepare_prox_dist_boundary_pts`
+  with idealized geometries (`test_ccta.py`, 17 tests).
+
+### Performance
+- Ray-intersection labeling step parallelized via `par_iter()`, reducing wall time on large meshes.
+
 ## [0.3.4] - 2026-05-13
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "multimodars"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multimodars"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 license = "MIT"
 

--- a/docs/tutorial_ccta.rst
+++ b/docs/tutorial_ccta.rst
@@ -374,6 +374,12 @@ geometry with a triangulated patch:
     this when the pullback axis is nearly aligned with the image z-axis, as is common for
     straight intramural segments.
 
+- ``clamp_overshoot``: minimum distance in mm that every proximal boundary point must sit
+  away from the IV plane after clamping (default 0.5).  Only active for anomalous ostia
+  where the boundary-ring plane and the IV plane diverge by ≥ 45°.  Increase this value
+  if stitching artefacts remain visible near the ostium; decrease it (toward 0.0) for
+  more tightly fitted geometries.
+
 The return value is a new ``results``-like dictionary that additionally contains:
 
 - ``"prox_boundary_points"`` — the ordered proximal boundary ring used for stitching.

--- a/multimodars/_converters.py
+++ b/multimodars/_converters.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 import numpy as np
 import trimesh
 from .multimodars import (
@@ -139,7 +141,9 @@ def _geometry_to_numpy(geom) -> dict[str, np.ndarray]:
                 if len(result[key]) == 0:
                     result[key] = frame_data[key]
                 else:
-                    result[key] = np.vstack([result[key], frame_data[key]])
+                    result[key] = cast(
+                        np.ndarray, np.vstack([result[key], frame_data[key]])
+                    )
 
     return result
 

--- a/multimodars/ccta/debug_plots.py
+++ b/multimodars/ccta/debug_plots.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import trimesh
 from trimesh.points import PointCloud
+from trimesh.visual import ColorVisuals
 
 if TYPE_CHECKING:
     from ..multimodars import PyCenterline
@@ -157,7 +158,12 @@ def compare_centerline_scaling(
     scene1 = trimesh.Scene(
         [original_mesh, PointCloud(region_array, colors=region_colors)]
     )
-    original_mesh.visual.face_colors = [200, 200, 200, 100]  # Semi-transparent
+    cast(ColorVisuals, original_mesh.visual).face_colors = [
+        200,
+        200,
+        200,
+        100,
+    ]  # Semi-transparent
 
     centerline_points = None
     centerline_colors = None
@@ -181,7 +187,12 @@ def compare_centerline_scaling(
     scene2 = trimesh.Scene(
         [scaled_mesh, PointCloud(region_array, colors=region_colors)]
     )
-    scaled_mesh.visual.face_colors = [200, 200, 200, 100]  # Semi-transparent
+    cast(ColorVisuals, scaled_mesh.visual).face_colors = [
+        200,
+        200,
+        200,
+        100,
+    ]  # Semi-transparent
 
     if centerline_points is not None:
         scene2.add_geometry(PointCloud(centerline_points, colors=centerline_colors))
@@ -196,8 +207,18 @@ def compare_centerline_scaling(
 
     scene3 = trimesh.Scene([original_mesh, scaled_mesh_shifted])
 
-    original_mesh.visual.face_colors = [0, 100, 200, 100]  # Blue-ish
-    scaled_mesh_shifted.visual.face_colors = [200, 100, 0, 100]  # Orange-ish
+    cast(ColorVisuals, original_mesh.visual).face_colors = [
+        0,
+        100,
+        200,
+        100,
+    ]  # Blue-ish
+    cast(ColorVisuals, scaled_mesh_shifted.visual).face_colors = [
+        200,
+        100,
+        0,
+        100,
+    ]  # Orange-ish
 
     if centerline_points is not None:
         centerline_shifted = centerline_points + shift_amount

--- a/multimodars/ccta/manipulating.py
+++ b/multimodars/ccta/manipulating.py
@@ -37,6 +37,37 @@ def _project_to_best_fit_plane(
     return [tuple(p) for p in projected]
 
 
+def _plane_normal_svd(pts: np.ndarray) -> np.ndarray:
+    """Best-fit plane normal for a point cloud via SVD (minimum-variance axis)."""
+    centroid = pts.mean(axis=0)
+    _, _, Vt = np.linalg.svd(pts - centroid, full_matrices=False)
+    return Vt[-1]
+
+
+def _angle_between_planes_deg(n1: np.ndarray, n2: np.ndarray) -> float:
+    """Acute angle in degrees between two planes given their normals."""
+    cos = np.clip(np.abs(np.dot(n1, n2)), 0.0, 1.0)
+    return float(np.degrees(np.arccos(cos)))
+
+
+def _clamp_to_plane(
+    points: list[tuple[float, float, float]],
+    plane_origin: np.ndarray,
+    plane_normal: np.ndarray,
+) -> list[tuple[float, float, float]]:
+    """Project any point on the wrong side of a plane back onto it.
+
+    The 'correct' side is determined by the majority of points.  Only
+    outliers that have crossed the plane are moved; all others are untouched.
+    """
+    pts = np.array(points, dtype=np.float64)
+    dists = (pts - plane_origin) @ plane_normal
+    correct_sign = np.sign(np.median(dists))
+    wrong = (np.sign(dists) != correct_sign) & (dists != 0.0)
+    pts[wrong] -= np.outer(dists[wrong], plane_normal)
+    return [tuple(p) for p in pts]
+
+
 def _smooth_ring_laplacian(
     points: list[tuple[float, float, float]],
     iterations: int = 5,
@@ -709,6 +740,7 @@ def stitch_ccta_to_intravascular(
         proximal_centroid,
         distal_centroid,
         proximal_is_ostium=proximal_is_ostium,
+        proximal_iv_frame_pts=iv_mesh.frames[0].lumen.points,
     )
     prox_point_step = len(proximal_points) // len(prox_boundary_pts)
     dist_point_step = len(distal_points) // len(dist_boundary_pts)
@@ -795,6 +827,8 @@ def _prepare_prox_dist_boundary_pts(
     prox_centroid: tuple[float, float, float],
     dist_centroid: tuple[float, float, float],
     proximal_is_ostium: bool = True,
+    proximal_iv_frame_pts=None,
+    ostium_angle_threshold_deg: float = 45.0,
 ) -> tuple[list, list, trimesh.Trimesh]:
     proximal_boundary_pts = []
     distal_boundary_pts = []
@@ -807,10 +841,28 @@ def _prepare_prox_dist_boundary_pts(
             distal_boundary_pts.append(pt)
 
     if proximal_is_ostium:
-        # Ostial fixing: project onto best-fit plane + Laplacian smooth, then
-        # update the corresponding mesh vertices so there is no gap at the seam.
+        # Project onto best-fit plane + Laplacian smooth.
         prox_projected = _project_to_best_fit_plane(proximal_boundary_pts)
         prox_boundary_pts_ord = _smooth_ring_laplacian(prox_projected)
+
+        # Final check for anomalous vessels: the aortic ostium is nearly
+        # perpendicular to the coronary ostial plane, which can leave some
+        # boundary points on the wrong side after smoothing.  Compare the two
+        # plane normals and, if the angle exceeds the threshold, project any
+        # outlier that crossed the IV-frame plane back onto it.
+        if proximal_iv_frame_pts is not None and len(prox_boundary_pts_ord) >= 3:
+            boundary_arr = np.array(prox_boundary_pts_ord, dtype=np.float64)
+            iv_arr = np.array(
+                [[p.x, p.y, p.z] for p in proximal_iv_frame_pts], dtype=np.float64
+            )
+            boundary_normal = _plane_normal_svd(boundary_arr)
+            iv_normal = _plane_normal_svd(iv_arr)
+            angle = _angle_between_planes_deg(boundary_normal, iv_normal)
+            if angle >= ostium_angle_threshold_deg:
+                iv_origin = np.array(prox_centroid, dtype=np.float64)
+                prox_boundary_pts_ord = _clamp_to_plane(
+                    prox_boundary_pts_ord, iv_origin, iv_normal
+                )
         coord_to_idx = {tuple(v): i for i, v in enumerate(mesh.vertices)}
         new_vertices = mesh.vertices.copy()
         for old_pt, new_pt in zip(proximal_boundary_pts, prox_boundary_pts_ord):

--- a/multimodars/ccta/manipulating.py
+++ b/multimodars/ccta/manipulating.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 import numpy as np
 import trimesh
 
@@ -14,6 +15,70 @@ from ..multimodars import (
     find_aortic_wall_scaling as _find_aortic_wall_scaling,
 )
 from .._converters import geometry_to_trimesh
+
+
+def _project_to_best_fit_plane(
+    points: list[tuple[float, float, float]],
+) -> list[tuple[float, float, float]]:
+    """Project a ring of boundary points onto their best-fit plane.
+
+    Fits a plane via SVD (the plane normal is the direction of minimum variance)
+    and orthogonally projects every point onto it, flattening noise perpendicular
+    to the ring.
+    """
+    if len(points) < 3:
+        return points
+    pts = np.array(points, dtype=np.float64)
+    centroid = pts.mean(axis=0)
+    _, _, Vt = np.linalg.svd(pts - centroid, full_matrices=False)
+    normal = Vt[-1]
+    distances = (pts - centroid) @ normal
+    projected = pts - np.outer(distances, normal)
+    return [tuple(p) for p in projected]
+
+
+def _order_boundary_components(
+    boundary_indices: set[int],
+    adj_map: Mapping[int, list[int] | set[int]],
+) -> list[list[int]]:
+    """Walk every connected component of the boundary in edge order.
+
+    Returns one ordered list per component so callers can project each ring
+    onto its own best-fit plane rather than a combined plane fitted to all rings.
+    """
+    if not boundary_indices:
+        return []
+    if len(boundary_indices) == 1:
+        return [list(boundary_indices)]
+
+    ring_adj = {
+        i: [j for j in adj_map.get(i, []) if j in boundary_indices]
+        for i in boundary_indices
+    }
+
+    remaining = set(boundary_indices)
+    components: list[list[int]] = []
+
+    while remaining:
+        start = next(iter(remaining))
+        component = [start]
+        remaining.discard(start)
+        prev, current = -1, start
+
+        while True:
+            nxt = next(
+                (n for n in ring_adj.get(current, []) if n != prev and n in remaining),
+                None,
+            )
+            if nxt is None:
+                break
+            component.append(nxt)
+            remaining.discard(nxt)
+            prev, current = current, nxt
+
+        components.append(component)
+
+    return components
 
 
 def scale_region_centerline_morphing(
@@ -370,7 +435,17 @@ def remove_labeled_points_from_mesh(
         for i in range(n_vertices)
         if keep_mask[i] and any(j in remove_indices for j in adj_map.get(i, []))
     }
-    boundary_points = [tuple(mesh.vertices[i]) for i in boundary_indices]
+    # Project each ring component onto its own best-fit plane so that a
+    # proximal and distal ring (produced by two separate removals) are each
+    # flattened independently rather than onto a single averaged plane.
+    components = _order_boundary_components(boundary_indices, adj_map)
+    ordered_boundary: list[tuple[int, tuple]] = []
+    boundary_points: list[tuple] = []
+    for component in components:
+        raw = [tuple(mesh.vertices[i]) for i in component]
+        projected = _project_to_best_fit_plane(raw)
+        ordered_boundary.extend(zip(component, projected))
+        boundary_points.extend(projected)
 
     # 4. Drop faces that reference any removed vertex
     face_keep_mask = np.all(keep_mask[mesh.faces], axis=1)
@@ -381,7 +456,13 @@ def remove_labeled_points_from_mesh(
     new_index[keep_mask] = np.arange(keep_mask.sum(), dtype=np.int64)
     new_faces = new_index[new_faces]
 
-    new_vertices = mesh.vertices[keep_mask]
+    # Update boundary vertices in the mesh to their projected positions so that
+    # new_coord_set and all downstream coordinate lookups stay consistent.
+    new_vertices = mesh.vertices[keep_mask].copy()
+    for orig_idx, proj_pt in ordered_boundary:
+        remapped = new_index[orig_idx]
+        if remapped >= 0:
+            new_vertices[remapped] = proj_pt
     new_mesh = trimesh.Trimesh(vertices=new_vertices, faces=new_faces, process=False)
 
     # 6. Rebuild the results dict with updated coordinate lists
@@ -475,7 +556,14 @@ def keep_labeled_points_from_mesh(
     boundary_indices = {
         i for i in keep_indices if any(j in remove_indices for j in adj_map.get(i, []))
     }
-    boundary_points = [tuple(mesh.vertices[i]) for i in boundary_indices]
+    components = _order_boundary_components(boundary_indices, adj_map)
+    ordered_boundary: list[tuple[int, tuple]] = []
+    boundary_points: list[tuple] = []
+    for component in components:
+        raw = [tuple(mesh.vertices[i]) for i in component]
+        projected = _project_to_best_fit_plane(raw)
+        ordered_boundary.extend(zip(component, projected))
+        boundary_points.extend(projected)
 
     # Drop faces that reference any removed vertex
     face_keep_mask = np.all(keep_mask[mesh.faces], axis=1)
@@ -486,7 +574,13 @@ def keep_labeled_points_from_mesh(
     new_index[keep_mask] = np.arange(keep_mask.sum(), dtype=np.int64)
     new_faces = new_index[new_faces]
 
-    new_vertices = mesh.vertices[keep_mask]
+    # Update boundary vertices in the mesh to their projected positions so that
+    # new_coord_set and all downstream coordinate lookups stay consistent.
+    new_vertices = mesh.vertices[keep_mask].copy()
+    for orig_idx, proj_pt in ordered_boundary:
+        remapped = new_index[orig_idx]
+        if remapped >= 0:
+            new_vertices[remapped] = proj_pt
     new_mesh = trimesh.Trimesh(vertices=new_vertices, faces=new_faces, process=False)
 
     new_coord_set = {tuple(v) for v in new_vertices}

--- a/multimodars/ccta/manipulating.py
+++ b/multimodars/ccta/manipulating.py
@@ -54,18 +54,37 @@ def _clamp_to_plane(
     points: list[tuple[float, float, float]],
     plane_origin: np.ndarray,
     plane_normal: np.ndarray,
+    overshoot: float = 0.0,
 ) -> list[tuple[float, float, float]]:
-    """Project any point on the wrong side of a plane back onto it.
+    """Clamp wrong-side points to the IV plane, then enforce a minimum gap.
 
-    The 'correct' side is determined by the majority of points.  Only
-    outliers that have crossed the plane are moved; all others are untouched.
+    Step 1: project any point on the wrong side of the plane onto it.
+    Step 2: if ``overshoot`` > 0, every point (including freshly clamped ones
+    that now sit exactly on the plane) that is within ``overshoot`` mm of the
+    plane on the correct side is pushed further away until it is exactly
+    ``overshoot`` mm from the plane.  This creates a clean buffer zone between
+    the aortic boundary ring and the IV ostium plane, avoiding the sharp angle
+    that would otherwise form.
     """
     pts = np.array(points, dtype=np.float64)
     dists = (pts - plane_origin) @ plane_normal
     correct_sign = np.sign(np.median(dists))
+
+    # Step 1: project wrong-side points onto the plane
     wrong = (np.sign(dists) != correct_sign) & (dists != 0.0)
     pts[wrong] -= np.outer(dists[wrong], plane_normal)
+
+    if overshoot > 0.0:
+        # Step 2: recompute distances and push any point within the buffer zone
+        # further away on the aortic (correct) side
+        dists2 = (pts - plane_origin) @ plane_normal
+        signed_dist = correct_sign * dists2  # positive = on correct side
+        too_close = signed_dist < overshoot
+        deficit = overshoot - signed_dist[too_close]
+        pts[too_close] += np.outer(deficit * correct_sign, plane_normal)
+
     return [tuple(p) for p in pts]
+
 
 
 def _smooth_ring_laplacian(
@@ -714,16 +733,20 @@ def stitch_ccta_to_intravascular(
     prox_start_mode: str = "nearest_iv",
     dist_start_mode: str = "nearest_iv",
     proximal_is_ostium: bool = True,
+    clamp_overshoot: float = 1.0,
 ) -> dict:
-    """
+    """Stitch an aligned intravascular mesh to a CCTA mesh.
+
     ``prox_start_mode`` / ``dist_start_mode`` control how index 0 of each
     boundary ring is chosen before stitching:
 
     * ``"nearest_iv"`` (default) - rotate to the point closest to IV point 0.
     * ``"highest_z"`` - rotate to the point with the largest z-coordinate.
-    """
-    """
-    Uses an aligned intravascular mesh and stitches it to a CCTA mesh using the following steps.
+
+    ``clamp_overshoot`` controls how far past the IV plane clamped ostium
+    points are pushed (as a fraction of their original displacement).  The
+    default 0.1 adds 10 % extra travel, creating a slight inward step that
+    softens the stitching angle.
     """
     iv_mesh = iv_mesh.downsample(n_points_iv_cont)
     iv_mesh_points = [
@@ -741,6 +764,7 @@ def stitch_ccta_to_intravascular(
         distal_centroid,
         proximal_is_ostium=proximal_is_ostium,
         proximal_iv_frame_pts=iv_mesh.frames[0].lumen.points,
+        clamp_overshoot=clamp_overshoot,
     )
     prox_point_step = len(proximal_points) // len(prox_boundary_pts)
     dist_point_step = len(distal_points) // len(dist_boundary_pts)
@@ -829,6 +853,7 @@ def _prepare_prox_dist_boundary_pts(
     proximal_is_ostium: bool = True,
     proximal_iv_frame_pts=None,
     ostium_angle_threshold_deg: float = 45.0,
+    clamp_overshoot: float = 1.0,
 ) -> tuple[list, list, trimesh.Trimesh]:
     proximal_boundary_pts = []
     distal_boundary_pts = []
@@ -861,7 +886,8 @@ def _prepare_prox_dist_boundary_pts(
             if angle >= ostium_angle_threshold_deg:
                 iv_origin = np.array(prox_centroid, dtype=np.float64)
                 prox_boundary_pts_ord = _clamp_to_plane(
-                    prox_boundary_pts_ord, iv_origin, iv_normal
+                    prox_boundary_pts_ord, iv_origin, iv_normal,
+                    overshoot=clamp_overshoot,
                 )
         coord_to_idx = {tuple(v): i for i, v in enumerate(mesh.vertices)}
         new_vertices = mesh.vertices.copy()

--- a/multimodars/ccta/manipulating.py
+++ b/multimodars/ccta/manipulating.py
@@ -37,6 +37,34 @@ def _project_to_best_fit_plane(
     return [tuple(p) for p in projected]
 
 
+def _smooth_ring_laplacian(
+    points: list[tuple[float, float, float]],
+    iterations: int = 5,
+    alpha: float = 0.5,
+) -> list[tuple[float, float, float]]:
+    """Laplacian smoothing of a closed boundary ring.
+
+    Each vertex is blended toward the midpoint of its two ring neighbors.
+    Since the input is already coplanar, the result stays on the same plane
+    (a linear combination of coplanar points is coplanar).
+
+    Parameters
+    ----------
+    iterations : int
+        Number of smoothing passes.
+    alpha : float
+        Weight kept on the original position (0 = full Laplacian, 1 = no-op).
+    """
+    if len(points) < 3:
+        return points
+    pts = np.array(points, dtype=np.float64)
+    for _ in range(iterations):
+        prev = pts.copy()
+        neighbor_avg = (np.roll(prev, 1, axis=0) + np.roll(prev, -1, axis=0)) / 2.0
+        pts = alpha * prev + (1.0 - alpha) * neighbor_avg
+    return [tuple(p) for p in pts]
+
+
 def _order_boundary_components(
     boundary_indices: set[int],
     adj_map: Mapping[int, list[int] | set[int]],
@@ -435,17 +463,10 @@ def remove_labeled_points_from_mesh(
         for i in range(n_vertices)
         if keep_mask[i] and any(j in remove_indices for j in adj_map.get(i, []))
     }
-    # Project each ring component onto its own best-fit plane so that a
-    # proximal and distal ring (produced by two separate removals) are each
-    # flattened independently rather than onto a single averaged plane.
     components = _order_boundary_components(boundary_indices, adj_map)
-    ordered_boundary: list[tuple[int, tuple]] = []
-    boundary_points: list[tuple] = []
-    for component in components:
-        raw = [tuple(mesh.vertices[i]) for i in component]
-        projected = _project_to_best_fit_plane(raw)
-        ordered_boundary.extend(zip(component, projected))
-        boundary_points.extend(projected)
+    boundary_points: list[tuple] = [
+        tuple(mesh.vertices[i]) for component in components for i in component
+    ]
 
     # 4. Drop faces that reference any removed vertex
     face_keep_mask = np.all(keep_mask[mesh.faces], axis=1)
@@ -456,13 +477,7 @@ def remove_labeled_points_from_mesh(
     new_index[keep_mask] = np.arange(keep_mask.sum(), dtype=np.int64)
     new_faces = new_index[new_faces]
 
-    # Update boundary vertices in the mesh to their projected positions so that
-    # new_coord_set and all downstream coordinate lookups stay consistent.
-    new_vertices = mesh.vertices[keep_mask].copy()
-    for orig_idx, proj_pt in ordered_boundary:
-        remapped = new_index[orig_idx]
-        if remapped >= 0:
-            new_vertices[remapped] = proj_pt
+    new_vertices = mesh.vertices[keep_mask]
     new_mesh = trimesh.Trimesh(vertices=new_vertices, faces=new_faces, process=False)
 
     # 6. Rebuild the results dict with updated coordinate lists
@@ -557,13 +572,9 @@ def keep_labeled_points_from_mesh(
         i for i in keep_indices if any(j in remove_indices for j in adj_map.get(i, []))
     }
     components = _order_boundary_components(boundary_indices, adj_map)
-    ordered_boundary: list[tuple[int, tuple]] = []
-    boundary_points: list[tuple] = []
-    for component in components:
-        raw = [tuple(mesh.vertices[i]) for i in component]
-        projected = _project_to_best_fit_plane(raw)
-        ordered_boundary.extend(zip(component, projected))
-        boundary_points.extend(projected)
+    boundary_points: list[tuple] = [
+        tuple(mesh.vertices[i]) for component in components for i in component
+    ]
 
     # Drop faces that reference any removed vertex
     face_keep_mask = np.all(keep_mask[mesh.faces], axis=1)
@@ -574,13 +585,7 @@ def keep_labeled_points_from_mesh(
     new_index[keep_mask] = np.arange(keep_mask.sum(), dtype=np.int64)
     new_faces = new_index[new_faces]
 
-    # Update boundary vertices in the mesh to their projected positions so that
-    # new_coord_set and all downstream coordinate lookups stay consistent.
-    new_vertices = mesh.vertices[keep_mask].copy()
-    for orig_idx, proj_pt in ordered_boundary:
-        remapped = new_index[orig_idx]
-        if remapped >= 0:
-            new_vertices[remapped] = proj_pt
+    new_vertices = mesh.vertices[keep_mask]
     new_mesh = trimesh.Trimesh(vertices=new_vertices, faces=new_faces, process=False)
 
     new_coord_set = {tuple(v) for v in new_vertices}
@@ -677,6 +682,7 @@ def stitch_ccta_to_intravascular(
     n_points_iv_cont: int = 100,
     prox_start_mode: str = "nearest_iv",
     dist_start_mode: str = "nearest_iv",
+    proximal_is_ostium: bool = True,
 ) -> dict:
     """
     ``prox_start_mode`` / ``dist_start_mode`` control how index 0 of each
@@ -697,11 +703,12 @@ def stitch_ccta_to_intravascular(
     proximal_points = iv_mesh.frames[0].lumen.points
     distal_points = iv_mesh.frames[-1].lumen.points
 
-    prox_boundary_pts, dist_boundary_pts = _prepare_prox_dist_boundary_pts(
+    prox_boundary_pts, dist_boundary_pts, mesh = _prepare_prox_dist_boundary_pts(
         mesh,
         results,
         proximal_centroid,
         distal_centroid,
+        proximal_is_ostium=proximal_is_ostium,
     )
     prox_point_step = len(proximal_points) // len(prox_boundary_pts)
     dist_point_step = len(distal_points) // len(dist_boundary_pts)
@@ -787,7 +794,8 @@ def _prepare_prox_dist_boundary_pts(
     results: dict,
     prox_centroid: tuple[float, float, float],
     dist_centroid: tuple[float, float, float],
-) -> tuple[list, list]:
+    proximal_is_ostium: bool = True,
+) -> tuple[list, list, trimesh.Trimesh]:
     proximal_boundary_pts = []
     distal_boundary_pts = []
     for pt in results["boundary_points"]:
@@ -798,10 +806,24 @@ def _prepare_prox_dist_boundary_pts(
         else:
             distal_boundary_pts.append(pt)
 
-    prox_boundary_pts_ord = order_points_list(mesh, proximal_boundary_pts)
+    if proximal_is_ostium:
+        # Ostial fixing: project onto best-fit plane + Laplacian smooth, then
+        # update the corresponding mesh vertices so there is no gap at the seam.
+        prox_projected = _project_to_best_fit_plane(proximal_boundary_pts)
+        prox_boundary_pts_ord = _smooth_ring_laplacian(prox_projected)
+        coord_to_idx = {tuple(v): i for i, v in enumerate(mesh.vertices)}
+        new_vertices = mesh.vertices.copy()
+        for old_pt, new_pt in zip(proximal_boundary_pts, prox_boundary_pts_ord):
+            idx = coord_to_idx.get(tuple(old_pt))
+            if idx is not None:
+                new_vertices[idx] = new_pt
+        mesh = trimesh.Trimesh(vertices=new_vertices, faces=mesh.faces, process=False)
+    else:
+        prox_boundary_pts_ord = order_points_list(mesh, proximal_boundary_pts)
+
     dist_boundary_pts_ord = order_points_list(mesh, distal_boundary_pts)
 
-    return prox_boundary_pts_ord, dist_boundary_pts_ord
+    return prox_boundary_pts_ord, dist_boundary_pts_ord, mesh
 
 
 def order_points_list(mesh: trimesh.Trimesh, points: list) -> list:

--- a/multimodars/ccta/manipulating.py
+++ b/multimodars/ccta/manipulating.py
@@ -733,7 +733,7 @@ def stitch_ccta_to_intravascular(
     prox_start_mode: str = "nearest_iv",
     dist_start_mode: str = "nearest_iv",
     proximal_is_ostium: bool = True,
-    clamp_overshoot: float = 1.0,
+    clamp_overshoot: float = 0.5,
 ) -> dict:
     """Stitch an aligned intravascular mesh to a CCTA mesh.
 
@@ -743,10 +743,15 @@ def stitch_ccta_to_intravascular(
     * ``"nearest_iv"`` (default) - rotate to the point closest to IV point 0.
     * ``"highest_z"`` - rotate to the point with the largest z-coordinate.
 
-    ``clamp_overshoot`` controls how far past the IV plane clamped ostium
-    points are pushed (as a fraction of their original displacement).  The
-    default 0.1 adds 10 % extra travel, creating a slight inward step that
-    softens the stitching angle.
+    ``clamp_overshoot`` sets the minimum distance (mm) that every proximal
+    boundary point must sit away from the IV plane after clamping.  Points
+    that land too close are pushed further until they are exactly
+    ``clamp_overshoot`` mm from the plane, creating a slight inward step that
+    softens the stitching angle.  The two mesh rings adjacent to the boundary
+    are also pushed radially outward (ring 1: 0.1 mm, ring 2: 0.2 mm) within
+    the IV plane to avoid ridges at the clamping zone.  Only active when the
+    boundary-ring plane and the IV plane form an angle ≥ ``ostium_angle_threshold_deg``
+    (default 45°).
     """
     iv_mesh = iv_mesh.downsample(n_points_iv_cont)
     iv_mesh_points = [

--- a/multimodars/ccta/manipulating.py
+++ b/multimodars/ccta/manipulating.py
@@ -845,6 +845,59 @@ def stitch_ccta_to_intravascular(
     return results
 
 
+def _enforce_layer_gap_from_plane(
+    mesh: trimesh.Trimesh,
+    seed_indices: set[int],
+    plane_origin: np.ndarray,
+    plane_normal: np.ndarray,
+    layer_step_mm: float = 0.1,
+    n_rings: int = 2,
+) -> trimesh.Trimesh:
+    """Push neighboring mesh rings radially away from the IV ring center.
+
+    The boundary ring was clamped toward the IV plane, which can leave second-
+    and third-layer aortic vertices sitting closer to the coronary axis than
+    the boundary ring itself — creating a visible ridge.  The fix is to push
+    those vertices outward *within* the IV plane (i.e. along the aortic
+    surface, away from the coronary center), not perpendicular to it.
+
+    Ring k is displaced by ``k * layer_step_mm`` in the radial direction:
+    the projection of the vertex onto the IV plane, measured from the IV
+    ring centre (``plane_origin``), gives the outward direction.
+    """
+    adj_map = build_adjacency_map(mesh.faces.tolist())
+    new_vertices = mesh.vertices.copy()
+
+    frontier = set(seed_indices)
+    visited = set(seed_indices)
+
+    for ring in range(1, n_rings + 1):
+        push_dist = ring * layer_step_mm
+        next_frontier = set()
+        for vi in frontier:
+            for nb in adj_map.get(vi, []):
+                if nb not in visited:
+                    next_frontier.add(nb)
+
+        for vi in next_frontier:
+            p = new_vertices[vi]
+            # Project the vertex onto the IV plane to get its lateral position
+            p_proj = p - float(np.dot(p - plane_origin, plane_normal)) * plane_normal
+            # Radial direction: from IV ring centre outward, within the IV plane
+            radial = p_proj - plane_origin
+            r_norm = np.linalg.norm(radial)
+            if r_norm < 1e-10:
+                continue
+            new_vertices[vi] = p + (push_dist / r_norm) * radial
+
+        visited.update(next_frontier)
+        frontier = next_frontier
+        if not frontier:
+            break
+
+    return trimesh.Trimesh(vertices=new_vertices, faces=mesh.faces, process=False)
+
+
 def _prepare_prox_dist_boundary_pts(
     mesh: trimesh.Trimesh,
     results: dict,
@@ -875,6 +928,9 @@ def _prepare_prox_dist_boundary_pts(
         # boundary points on the wrong side after smoothing.  Compare the two
         # plane normals and, if the angle exceeds the threshold, project any
         # outlier that crossed the IV-frame plane back onto it.
+        iv_origin: np.ndarray | None = None
+        iv_normal: np.ndarray | None = None
+        clamping_applied = False
         if proximal_iv_frame_pts is not None and len(prox_boundary_pts_ord) >= 3:
             boundary_arr = np.array(prox_boundary_pts_ord, dtype=np.float64)
             iv_arr = np.array(
@@ -889,13 +945,22 @@ def _prepare_prox_dist_boundary_pts(
                     prox_boundary_pts_ord, iv_origin, iv_normal,
                     overshoot=clamp_overshoot,
                 )
+                clamping_applied = True
+
         coord_to_idx = {tuple(v): i for i, v in enumerate(mesh.vertices)}
         new_vertices = mesh.vertices.copy()
+        fixed_indices: set[int] = set()
         for old_pt, new_pt in zip(proximal_boundary_pts, prox_boundary_pts_ord):
             idx = coord_to_idx.get(tuple(old_pt))
             if idx is not None:
                 new_vertices[idx] = new_pt
+                fixed_indices.add(idx)
         mesh = trimesh.Trimesh(vertices=new_vertices, faces=mesh.faces, process=False)
+
+        if clamping_applied and fixed_indices:
+            mesh = _enforce_layer_gap_from_plane(
+                mesh, fixed_indices, iv_origin, iv_normal
+            )
     else:
         prox_boundary_pts_ord = order_points_list(mesh, proximal_boundary_pts)
 

--- a/multimodars/ccta/manipulating.py
+++ b/multimodars/ccta/manipulating.py
@@ -86,7 +86,6 @@ def _clamp_to_plane(
     return [tuple(p) for p in pts]
 
 
-
 def _smooth_ring_laplacian(
     points: list[tuple[float, float, float]],
     iterations: int = 5,
@@ -947,7 +946,9 @@ def _prepare_prox_dist_boundary_pts(
             if angle >= ostium_angle_threshold_deg:
                 iv_origin = np.array(prox_centroid, dtype=np.float64)
                 prox_boundary_pts_ord = _clamp_to_plane(
-                    prox_boundary_pts_ord, iv_origin, iv_normal,
+                    prox_boundary_pts_ord,
+                    iv_origin,
+                    iv_normal,
                     overshoot=clamp_overshoot,
                 )
                 clamping_applied = True
@@ -963,6 +964,7 @@ def _prepare_prox_dist_boundary_pts(
         mesh = trimesh.Trimesh(vertices=new_vertices, faces=mesh.faces, process=False)
 
         if clamping_applied and fixed_indices:
+            assert iv_origin is not None and iv_normal is not None
             mesh = _enforce_layer_gap_from_plane(
                 mesh, fixed_indices, iv_origin, iv_normal
             )

--- a/multimodars/io/__init__.py
+++ b/multimodars/io/__init__.py
@@ -1,2 +1,2 @@
-from . import read_geometrical
-from . import write_geometries
+from . import read_geometrical as read_geometrical
+from . import write_geometries as write_geometries

--- a/multimodars/io/read_geometrical.py
+++ b/multimodars/io/read_geometrical.py
@@ -4,6 +4,7 @@ import trimesh
 from pathlib import Path
 import warnings
 
+
 def read_mesh(path: Path | str) -> trimesh.base.Trimesh:
     """Load a mesh from disk and attempt lightweight repairs.
 
@@ -61,6 +62,8 @@ def read_mesh(path: Path | str) -> trimesh.base.Trimesh:
         warnings.warn(f"fill_holes failed for mesh from {path}", RuntimeWarning)
 
     if not mesh.is_watertight:
-        warnings.warn(f"Mesh from {path} is not watertight after repairs", RuntimeWarning)
+        warnings.warn(
+            f"Mesh from {path} is not watertight after repairs", RuntimeWarning
+        )
 
     return mesh

--- a/multimodars/io/write_geometries.py
+++ b/multimodars/io/write_geometries.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 from ..multimodars import PyCenterline
 
+
 def centerline_to_obj(cl, filename: str) -> None:
     """
     Write out a centerline as an OBJ with:
@@ -16,11 +17,11 @@ def centerline_to_obj(cl, filename: str) -> None:
     """
     if not isinstance(cl, PyCenterline):
         raise TypeError("Expected PyCenterline instance")
-    
+
     with open(filename, "w") as f:
         good_pts = []
         for i, pt in enumerate(cl.points):
-            x,y,z = pt.contour_point.x, pt.contour_point.y, pt.contour_point.z
+            x, y, z = pt.contour_point.x, pt.contour_point.y, pt.contour_point.z
             if not (math.isfinite(x) and math.isfinite(y) and math.isfinite(z)):
                 # skip any malformed point
                 continue
@@ -30,16 +31,16 @@ def centerline_to_obj(cl, filename: str) -> None:
         has_normals = any(
             math.isfinite(nx) and math.isfinite(ny) and math.isfinite(nz)
             for pt in good_pts
-            for nx,ny,nz in [pt.normal]
+            for nx, ny, nz in [pt.normal]
         )
         if has_normals:
             for pt in good_pts:
-                nx,ny,nz = pt.normal
+                nx, ny, nz = pt.normal
                 if math.isfinite(nx) and math.isfinite(ny) and math.isfinite(nz):
                     f.write(f"vn {nx:.6f} {ny:.6f} {nz:.6f}\n")
                 else:
                     f.write("vn 0.000000 0.000000 0.000000\n")
 
-        idxs = " ".join(str(i+1) for i in range(len(good_pts)))
+        idxs = " ".join(str(i + 1) for i in range(len(good_pts)))
         f.write(f"l {idxs}\n")
     print(f"Wrote {len(good_pts)} valid points to {filename!r}")

--- a/src/ccta/adjust_mesh/label_coronary.rs
+++ b/src/ccta/adjust_mesh/label_coronary.rs
@@ -367,8 +367,7 @@ mod test_find_cl_bounded_points {
         for expected_point in &points_inside {
             assert!(
                 result.contains(expected_point),
-                "Missing point: {:?}",
-                expected_point
+                "Missing point: {expected_point:?}"
             );
         }
 
@@ -376,8 +375,7 @@ mod test_find_cl_bounded_points {
         for outside_point in &points_outside {
             assert!(
                 !result.contains(outside_point),
-                "Unexpected point: {:?}",
-                outside_point
+                "Unexpected point: {outside_point:?}"
             );
         }
     }
@@ -394,10 +392,10 @@ mod test_find_cl_bounded_points {
         let result = ray_triangle_intersection(&ray_origin, &ray_direction, &triangle);
 
         println!("=== Single Ray-Triangle Test ===");
-        println!("Ray origin: {:?}", ray_origin);
-        println!("Ray direction: {:?}", ray_direction);
-        println!("Triangle: {:?}", triangle);
-        println!("Intersection result: {:?}", result);
+        println!("Ray origin: {ray_origin:?}");
+        println!("Ray direction: {ray_direction:?}");
+        println!("Triangle: {triangle:?}");
+        println!("Intersection result: {result:?}");
 
         assert!(result.is_some(), "Ray should intersect triangle");
         assert!(

--- a/src/intravascular/binding/classes.rs
+++ b/src/intravascular/binding/classes.rs
@@ -174,7 +174,7 @@ impl TryFrom<&PyInputData> for InputData {
             py_in.diastole,
             py_in.label.clone(),
         )
-        .map_err(|e| anyhow!("InputData::new failed: {:?}", e))
+        .map_err(|e| anyhow!("InputData::new failed: {e:?}"))
     }
 }
 
@@ -724,8 +724,7 @@ impl PyContourType {
             "catheter" => Ok(PyContourType::Catheter),
             "wall" => Ok(PyContourType::Wall),
             _ => Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "Unknown contour type: '{}'. Valid types are: lumen, eem, calcification, sidebranch, catheter, wall",
-                name
+                "Unknown contour type: '{name}'. Valid types are: lumen, eem, calcification, sidebranch, catheter, wall"
             ))),
         }
     }

--- a/src/intravascular/binding/entry.rs
+++ b/src/intravascular/binding/entry.rs
@@ -196,7 +196,7 @@ pub fn full_processing_rs(
             bool_d,
         ))
     })
-    .map_err(|e| anyhow!("Thread execution failed: {:?}", e))??;
+    .map_err(|e| anyhow!("Thread execution failed: {e:?}"))??;
 
     // First parallel batch: AB and CD (independent pairs)
     let (geom_pair_ab, geom_pair_cd) = thread::scope(|s| -> Result<(GeometryPair, GeometryPair)> {
@@ -221,7 +221,7 @@ pub fn full_processing_rs(
 
         Ok((geom_pair_ab, geom_pair_cd))
     })
-    .map_err(|e| anyhow!("Thread execution failed: {:?}", e))??;
+    .map_err(|e| anyhow!("Thread execution failed: {e:?}"))??;
 
     // Second parallel batch: AC and BD (independent pairs)
     let (geom_pair_ac, geom_pair_bd) = thread::scope(|s| -> Result<(GeometryPair, GeometryPair)> {
@@ -246,7 +246,7 @@ pub fn full_processing_rs(
 
         Ok((geom_pair_ac, geom_pair_bd))
     })
-    .map_err(|e| anyhow!("Thread execution failed: {:?}", e))??;
+    .map_err(|e| anyhow!("Thread execution failed: {e:?}"))??;
 
     // safety, if any pair is anomalous try to build wall with aortic thickness, fallback anyways just wall 1mm offset.
     let anomalous = bool_a || bool_b || bool_c || bool_d;
@@ -462,7 +462,7 @@ pub fn double_pair_processing_rs(
             bool_d,
         ))
     })
-    .map_err(|e| anyhow!("Thread execution failed: {:?}", e))??;
+    .map_err(|e| anyhow!("Thread execution failed: {e:?}"))??;
 
     // First parallel batch: AB and CD (independent pairs)
     let (geom_pair_ab, geom_pair_cd) = thread::scope(|s| -> Result<(GeometryPair, GeometryPair)> {
@@ -487,7 +487,7 @@ pub fn double_pair_processing_rs(
 
         Ok((geom_pair_ab, geom_pair_cd))
     })
-    .map_err(|e| anyhow!("Thread execution failed: {:?}", e))??;
+    .map_err(|e| anyhow!("Thread execution failed: {e:?}"))??;
 
     let anomalous = bool_a || bool_b || bool_c || bool_d;
 
@@ -610,7 +610,7 @@ pub fn pair_processing_rs(
 
             Ok((geom_a, geom_b, logs_a, logs_b, bool_a, bool_b))
         })
-        .map_err(|e| anyhow!("Thread execution failed: {:?}", e))??;
+        .map_err(|e| anyhow!("Thread execution failed: {e:?}"))??;
 
     let geom_pair =
         align_between_geometries(&mut geom_a, &mut geom_b, range_deg, step_deg, sample_size)
@@ -702,10 +702,7 @@ pub fn single_processing_rs(
             let contours = extract_contours_by_type(&geom, *contour_type);
 
             if contours.is_empty() {
-                eprintln!(
-                    "Warning: No contours found for type {:?}, skipping",
-                    contour_type
-                );
+                eprintln!("Warning: No contours found for type {contour_type:?}, skipping");
                 continue;
             }
 
@@ -725,7 +722,7 @@ pub fn single_processing_rs(
                 mtl_path.to_str().unwrap(),
                 watertight,
             )
-            .context(format!("Failed to write OBJ for {}", type_name))?;
+            .context(format!("Failed to write OBJ for {type_name}"))?;
         }
 
         println!(

--- a/src/intravascular/binding/mod.rs
+++ b/src/intravascular/binding/mod.rs
@@ -229,7 +229,7 @@ pub fn from_file_full(
         sample_size,
         postprocessing,
     )
-    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{:#}", e)))?;
+    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#}")))?;
 
     let py_geom_ab = geom_ab_final.into();
     let py_geom_cd = geom_cd_final.into();
@@ -401,7 +401,7 @@ pub fn from_file_doublepair(
         sample_size,
         postprocessing,
     )
-    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{:#}", e)))?;
+    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#}")))?;
 
     let py_geom_ab = geom_ab_final.into();
     let py_geom_cd = geom_cd_final.into();
@@ -559,7 +559,7 @@ pub fn from_file_singlepair(
         sample_size,
         postprocessing,
     )
-    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{:#}", e)))?;
+    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#}")))?;
 
     let py_geom_ab = geom_pair_final.into();
     let py_logs_a = logs_to_tuples(logs_a);
@@ -695,7 +695,7 @@ pub fn from_file_single(
         bruteforce,
         sample_size,
     )
-    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{:#}", e)))?;
+    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#}")))?;
 
     let py_geom = geom.into();
     let py_logs = logs_to_tuples(logs);
@@ -857,16 +857,16 @@ pub fn from_array_full(
         contour_types.iter().map(|ct| ct.into()).collect();
 
     let input_data_a_rust: InputData = input_data_a.try_into().map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_a: {}", e))
+        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_a: {e}"))
     })?;
     let input_data_b_rust: InputData = input_data_b.try_into().map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_b: {}", e))
+        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_b: {e}"))
     })?;
     let input_data_c_rust: InputData = input_data_c.try_into().map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_c: {}", e))
+        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_c: {e}"))
     })?;
     let input_data_d_rust: InputData = input_data_d.try_into().map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_d: {}", e))
+        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_d: {e}"))
     })?;
 
     let (
@@ -904,7 +904,7 @@ pub fn from_array_full(
         sample_size,
         postprocessing,
     )
-    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{:#}", e)))?;
+    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#}")))?;
 
     let py_geom_ab = geom_ab_final.into();
     let py_geom_cd = geom_cd_final.into();
@@ -1064,16 +1064,16 @@ pub fn from_array_doublepair(
         contour_types.iter().map(|ct| ct.into()).collect();
 
     let input_data_a_rust: InputData = input_data_a.try_into().map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_a: {}", e))
+        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_a: {e}"))
     })?;
     let input_data_b_rust: InputData = input_data_b.try_into().map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_b: {}", e))
+        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_b: {e}"))
     })?;
     let input_data_c_rust: InputData = input_data_c.try_into().map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_c: {}", e))
+        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_c: {e}"))
     })?;
     let input_data_d_rust: InputData = input_data_d.try_into().map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_d: {}", e))
+        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_d: {e}"))
     })?;
 
     let (geom_ab_final, geom_cd_final, logs_a, logs_b, logs_c, logs_d) = double_pair_processing_rs(
@@ -1100,7 +1100,7 @@ pub fn from_array_doublepair(
         sample_size,
         postprocessing,
     )
-    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{:#}", e)))?;
+    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#}")))?;
 
     let py_geom_ab = geom_ab_final.into();
     let py_geom_cd = geom_cd_final.into();
@@ -1235,10 +1235,10 @@ pub fn from_array_singlepair(
         contour_types.iter().map(|ct| ct.into()).collect();
 
     let input_data_a_rust: InputData = input_data_a.try_into().map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_a: {}", e))
+        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_a: {e}"))
     })?;
     let input_data_b_rust: InputData = input_data_b.try_into().map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_b: {}", e))
+        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_b: {e}"))
     })?;
 
     let (geom_ab_final, logs_a, logs_b) = pair_processing_rs(
@@ -1261,7 +1261,7 @@ pub fn from_array_singlepair(
         sample_size,
         postprocessing,
     )
-    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{:#}", e)))?;
+    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#}")))?;
 
     let py_geom_ab = geom_ab_final.into();
     let py_logs_a = logs_to_tuples(logs_a);
@@ -1372,7 +1372,7 @@ pub fn from_array_single(
         contour_types.iter().map(|ct| ct.into()).collect();
 
     let input_data_rust: InputData = input_data.try_into().map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_a: {}", e))
+        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert input_data_a: {e}"))
     })?;
 
     let (geom_rs, logs) = single_processing_rs(
@@ -1393,7 +1393,7 @@ pub fn from_array_single(
         bruteforce,
         sample_size,
     )
-    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{:#}", e)))?;
+    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#}")))?;
 
     let py_geom = PyGeometry::from(geom_rs);
     let py_logs = logs_to_tuples(logs);
@@ -1445,14 +1445,13 @@ pub fn to_obj(
 ) -> PyResult<()> {
     // Convert the Python geometry to Rust representation
     let geometry_rs = geometry.to_rust_geometry().map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert geometry: {}", e))
+        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to convert geometry: {e}"))
     })?;
 
     // Ensure output directory exists
     std::fs::create_dir_all(output_path).map_err(|e| {
         pyo3::exceptions::PyRuntimeError::new_err(format!(
-            "Could not create output directory '{}': {}",
-            output_path, e
+            "Could not create output directory '{output_path}': {e}"
         ))
     })?;
 
@@ -1461,23 +1460,20 @@ pub fn to_obj(
         let contours = extract_contours_by_type(&geometry_rs, contour_type.into());
 
         if contours.is_empty() {
-            eprintln!(
-                "Warning: No contours found for type {:?}, skipping",
-                contour_type
-            );
+            eprintln!("Warning: No contours found for type {contour_type:?}, skipping");
             continue;
         }
 
         let type_name = get_contour_type_name(contour_type.into());
         let filename = if filename_prefix.is_empty() {
-            format!("{}.obj", type_name)
+            format!("{type_name}.obj")
         } else {
-            format!("{}_{}.obj", filename_prefix, type_name)
+            format!("{filename_prefix}_{type_name}.obj")
         };
         let material_name = if filename_prefix.is_empty() {
-            format!("{}.mtl", type_name)
+            format!("{type_name}.mtl")
         } else {
-            format!("{}_{}.mtl", filename_prefix, type_name)
+            format!("{filename_prefix}_{type_name}.mtl")
         };
 
         let obj_path = Path::new(output_path).join(&filename);
@@ -1486,8 +1482,7 @@ pub fn to_obj(
         // Create appropriate MTL file based on contour type
         create_mtl_for_contour_type(contour_type.into(), &mtl_path, &filename).map_err(|e| {
             pyo3::exceptions::PyRuntimeError::new_err(format!(
-                "Failed to create mtl for geometry: {}",
-                e
+                "Failed to create mtl for geometry: {e}"
             ))
         })?;
 
@@ -1500,8 +1495,7 @@ pub fn to_obj(
         )
         .map_err(|e| {
             pyo3::exceptions::PyRuntimeError::new_err(format!(
-                "Failed to write {} OBJ: {}",
-                type_name, e
+                "Failed to write {type_name} OBJ: {e}"
             ))
         })?;
 

--- a/src/intravascular/centerline_align/mod.rs
+++ b/src/intravascular/centerline_align/mod.rs
@@ -79,12 +79,12 @@ pub fn align_three_point_rs<T: Processable>(
     case_name: &str,
 ) -> anyhow::Result<(T, Centerline)> {
     let resampled_centerline = preprocess_centerline(centerline, target.primary_geometry())
-        .map_err(|e| anyhow!("Couldn't resample the centerline: {}", e))?;
+        .map_err(|e| anyhow!("Couldn't resample the centerline: {e}"))?;
 
     let ref_idx = target
         .primary_geometry()
         .find_ref_frame_idx()
-        .map_err(|e| anyhow!("Couldn't find ref frame idx: {:?}", e))?;
+        .map_err(|e| anyhow!("Couldn't find ref frame idx: {e:?}"))?;
     let ref_point = target.primary_geometry().frames[ref_idx]
         .reference_point
         .as_ref()
@@ -113,7 +113,7 @@ pub fn align_three_point_rs<T: Processable>(
                 watertight,
                 &contour_types,
             )
-            .map_err(|e| anyhow!("Failed to write obj: {}", e))?
+            .map_err(|e| anyhow!("Failed to write obj: {e}"))?
     } else {
         target
     };
@@ -134,7 +134,7 @@ pub fn align_manual_rs<T: Processable>(
     case_name: &str,
 ) -> anyhow::Result<(T, Centerline)> {
     let resampled_centerline = preprocess_centerline(centerline, target.primary_geometry())
-        .map_err(|e| anyhow!("Couldn't resample the centerline: {}", e))?;
+        .map_err(|e| anyhow!("Couldn't resample the centerline: {e}"))?;
 
     target = rotate_by_best_rotation(target, rotation_angle_deg.to_radians());
     target = apply_transformations(target, &resampled_centerline, &ref_pt);
@@ -148,7 +148,7 @@ pub fn align_manual_rs<T: Processable>(
                 watertight,
                 &contour_types,
             )
-            .map_err(|e| anyhow!("Failed to write obj: {}", e))?
+            .map_err(|e| anyhow!("Failed to write obj: {e}"))?
     } else {
         target
     };
@@ -180,12 +180,12 @@ pub fn align_combined_rs<T: Processable>(
 
     let resampled_centerline =
         preprocess_centerline(centerline.clone(), original.primary_geometry())
-            .map_err(|e| anyhow!("Couldn't resample the centerline: {}", e))?;
+            .map_err(|e| anyhow!("Couldn't resample the centerline: {e}"))?;
 
     let ref_idx = original
         .primary_geometry()
         .find_ref_frame_idx()
-        .map_err(|e| anyhow!("Couldn't find ref frame idx: {:?}", e))?;
+        .map_err(|e| anyhow!("Couldn't find ref frame idx: {e:?}"))?;
 
     let ref_point = original.primary_geometry().frames[ref_idx]
         .reference_point
@@ -231,7 +231,7 @@ pub fn align_combined_rs<T: Processable>(
         total_rotation.to_degrees()
     );
     let diff = initial_cl_ref_idx as i32 - refined_cl_ref_idx as i32;
-    println!("Moving ostium by {} centerline points", diff);
+    println!("Moving ostium by {diff} centerline points");
 
     let refined_ref_pt = (
         resampled_centerline.points[refined_cl_ref_idx]
@@ -260,7 +260,7 @@ pub fn align_combined_rs<T: Processable>(
                 watertight,
                 &contour_types,
             )
-            .map_err(|e| anyhow!("Failed to write obj: {}", e))?
+            .map_err(|e| anyhow!("Failed to write obj: {e}"))?
     } else {
         final_target
     };

--- a/src/intravascular/io/geometry.rs
+++ b/src/intravascular/io/geometry.rs
@@ -166,7 +166,7 @@ impl Contour {
 
         for (original_frame_idx, points) in sorted_groups {
             let sequential_id = *frame_mapping.get(&original_frame_idx).ok_or_else(|| {
-                anyhow::anyhow!("No mapping found for original frame {}", original_frame_idx)
+                anyhow::anyhow!("No mapping found for original frame {original_frame_idx}")
             })?;
 
             let (aortic, pulmonary) = if let Some(ref meas) = measurements {
@@ -1339,7 +1339,7 @@ mod geometry_tests {
         let rotation_deg: f64 = 15.0;
 
         geometry_rotate.rotate_geometry(rotation_deg.to_radians());
-        geometry_rotate.rotate_geometry(-1.0 * rotation_deg.to_radians());
+        geometry_rotate.rotate_geometry(-rotation_deg.to_radians());
 
         assert_eq!(
             geometry.frames[0].lumen.points[0],
@@ -1347,7 +1347,7 @@ mod geometry_tests {
         );
 
         geometry_rotate.frames[0].rotate_frame(rotation_deg.to_radians());
-        geometry_rotate.frames[0].rotate_frame(-1.0 * rotation_deg.to_radians());
+        geometry_rotate.frames[0].rotate_frame(-rotation_deg.to_radians());
 
         assert_eq!(
             geometry.frames[0].lumen.points[0],
@@ -1359,7 +1359,7 @@ mod geometry_tests {
             .rotate_contour(rotation_deg.to_radians());
         geometry_rotate.frames[0]
             .lumen
-            .rotate_contour(-1.0 * rotation_deg.to_radians());
+            .rotate_contour(-rotation_deg.to_radians());
 
         assert_eq!(
             geometry.frames[0].lumen.points[0],
@@ -1370,7 +1370,7 @@ mod geometry_tests {
         geometry_rotate.frames[0].lumen.points[0]
             .rotate_point(rotation_deg.to_radians(), (center.0, center.1));
         geometry_rotate.frames[0].lumen.points[0]
-            .rotate_point(-1.0 * rotation_deg.to_radians(), (center.0, center.1));
+            .rotate_point(-rotation_deg.to_radians(), (center.0, center.1));
 
         assert_eq!(
             geometry.frames[0].lumen.points[0],
@@ -1910,8 +1910,7 @@ mod geometry_tests {
             assert_eq!(
                 (p.x, p.y, p.z),
                 expected_lumen[i],
-                "lumen point {} mismatch",
-                i
+                "lumen point {i} mismatch"
             );
         }
 
@@ -1926,7 +1925,7 @@ mod geometry_tests {
             (1.0, 1.0, 3.0),
         ];
         for (i, p) in rotated_eem.points.iter().enumerate() {
-            assert_eq!((p.x, p.y, p.z), expected_eem[i], "eem point {} mismatch", i);
+            assert_eq!((p.x, p.y, p.z), expected_eem[i], "eem point {i} mismatch");
         }
 
         // Reference point should also have been translated
@@ -2003,8 +2002,7 @@ mod geometry_tests {
         let area = c.area();
         assert!(
             (area - 6.0).abs() < 1e-6,
-            "triangle area should be 6.0, got {}",
-            area
+            "triangle area should be 6.0, got {area}"
         );
     }
 
@@ -2666,7 +2664,7 @@ mod geometry_tests {
 
         println!("Before smoothing:");
         for (i, frame) in geometry.frames.iter().enumerate() {
-            println!("Frame {}:", i);
+            println!("Frame {i}:");
             for point in &frame.lumen.points {
                 println!("  Point: ({:.2}, {:.2}, {:.2})", point.x, point.y, point.z);
             }
@@ -2677,7 +2675,7 @@ mod geometry_tests {
 
         println!("\nAfter smoothing:");
         for (i, frame) in smoothed_geometry.frames.iter().enumerate() {
-            println!("Frame {}:", i);
+            println!("Frame {i}:");
             for point in &frame.lumen.points {
                 println!("  Point: ({:.2}, {:.2}, {:.2})", point.x, point.y, point.z);
             }

--- a/src/intravascular/io/input.rs
+++ b/src/intravascular/io/input.rs
@@ -74,27 +74,25 @@ impl InputData {
         let phase = if diastole { "diastolic" } else { "systolic" };
 
         // Read required files - these will crash if missing
-        let contours_fname = format!("{}_contours.csv", phase);
+        let contours_fname = format!("{phase}_contours.csv");
         let contours_path = path.join(&contours_fname);
         let lumen = if contours_path.exists() {
             ContourPoint::read_contour_data(&contours_path)
                 .with_context(|| format!("reading {}", contours_path.display()))?
         } else {
             return Err(anyhow::anyhow!(
-                "required contours file missing: {:?}",
-                contours_path
+                "required contours file missing: {contours_path:?}"
             ));
         };
 
-        let ref_fname = format!("{}_reference_points.csv", phase);
+        let ref_fname = format!("{phase}_reference_points.csv");
         let ref_path = path.join(&ref_fname);
         let ref_point = if ref_path.exists() {
             ContourPoint::read_reference_point(&ref_path)
                 .with_context(|| format!("reading {}", ref_path.display()))?
         } else {
             return Err(anyhow::anyhow!(
-                "required reference-point file missing: {:?}",
-                ref_path
+                "required reference-point file missing: {ref_path:?}"
             ));
         };
 
@@ -114,7 +112,7 @@ impl InputData {
                                 .with_context(|| format!("reading {}", p.display()))?,
                         );
                     } else {
-                        eprintln!("sidebranch file not found, skipping: {:?}", p);
+                        eprintln!("sidebranch file not found, skipping: {p:?}");
                     }
                 }
 
@@ -127,7 +125,7 @@ impl InputData {
                                 .with_context(|| format!("reading {}", p.display()))?,
                         );
                     } else {
-                        eprintln!("calcification file not found, skipping: {:?}", p);
+                        eprintln!("calcification file not found, skipping: {p:?}");
                     }
                 }
 
@@ -140,7 +138,7 @@ impl InputData {
                                 .with_context(|| format!("reading {}", p.display()))?,
                         );
                     } else {
-                        eprintln!("eem file not found, skipping: {:?}", p);
+                        eprintln!("eem file not found, skipping: {p:?}");
                     }
                 }
 
@@ -152,15 +150,12 @@ impl InputData {
                             read_records(&p).with_context(|| format!("reading {}", p.display()))?,
                         );
                     } else {
-                        eprintln!("records file not found, skipping: {:?}", p);
+                        eprintln!("records file not found, skipping: {p:?}");
                     }
                 }
 
                 other => {
-                    eprintln!(
-                        "process_directory: unknown mapping name '{}', skipping",
-                        other
-                    );
+                    eprintln!("process_directory: unknown mapping name '{other}', skipping");
                 }
             }
         }
@@ -254,9 +249,9 @@ impl ContourPoint {
             match result {
                 Ok(record) => match record.deserialize(None) {
                     Ok(point) => points.push(point),
-                    Err(e) => eprintln!("Skipping invalid record: {:?}", e),
+                    Err(e) => eprintln!("Skipping invalid record: {e:?}"),
                 },
-                Err(e) => eprintln!("Skipping invalid row: {:?}", e),
+                Err(e) => eprintln!("Skipping invalid row: {e:?}"),
             }
         }
 

--- a/src/intravascular/io/integrity_check.rs
+++ b/src/intravascular/io/integrity_check.rs
@@ -112,7 +112,7 @@ fn check_reference_point(geometry: &Geometry) -> Result<()> {
 
     match reference_frames.len() {
         1 => Ok(()),
-        n => Err(anyhow!("Expected exactly one reference point, found {}", n)),
+        n => Err(anyhow!("Expected exactly one reference point, found {n}")),
     }
 }
 
@@ -214,10 +214,7 @@ fn check_proximal_end_index(geometry: &Geometry) -> Result<()> {
 
     if proximal_idx != min_idx {
         return Err(anyhow!(
-            "Proximal end index is {}, but frame with minimum z is {} (z={}).",
-            proximal_idx,
-            min_idx,
-            min_z
+            "Proximal end index is {proximal_idx}, but frame with minimum z is {min_idx} (z={min_z})."
         ));
     }
     Ok(())
@@ -229,9 +226,7 @@ fn check_z_distribution(geometry: &Geometry) -> Result<()> {
     let z_pos_n = geometry.frames[n - 1].centroid.2;
     if z_pos_zero > z_pos_n {
         return Err(anyhow!(
-            "First frame has higher z-coords {} than last frame {}",
-            z_pos_zero,
-            z_pos_n,
+            "First frame has higher z-coords {z_pos_zero} than last frame {z_pos_n}",
         ));
     }
     Ok(())

--- a/src/intravascular/io/mod.rs
+++ b/src/intravascular/io/mod.rs
@@ -293,10 +293,7 @@ mod io_tests {
                             .or_default()
                             .push(contour.original_frame);
                     }
-                    None => panic!(
-                        "Frame {} missing expected contour type {:?}",
-                        idx, wanted_type
-                    ),
+                    None => panic!("Frame {idx} missing expected contour type {wanted_type:?}"),
                 }
             }
         }
@@ -333,13 +330,11 @@ mod io_tests {
                 let of = orig_map.get(t).unwrap()[i];
                 assert_eq!(
                     id, first_id,
-                    "mismatched id at frame {}: {:?} has id {}, but {:?} has {}",
-                    i, first_type, first_id, t, id
+                    "mismatched id at frame {i}: {first_type:?} has id {first_id}, but {t:?} has {id}"
                 );
                 assert_eq!(
                     of, first_of,
-                    "mismatched original_frame at frame {}: {:?} has {}, but {:?} has {}",
-                    i, first_type, first_of, t, of
+                    "mismatched original_frame at frame {i}: {first_type:?} has {first_of}, but {t:?} has {of}"
                 );
             }
         }

--- a/src/intravascular/io/output.rs
+++ b/src/intravascular/io/output.rs
@@ -15,7 +15,7 @@ pub fn write_obj_mesh(
 ) -> anyhow::Result<()> {
     if let Some(parent) = Path::new(filename).parent() {
         std::fs::create_dir_all(parent)
-            .context(format!("Could not create output directory: {:?}", parent))?;
+            .context(format!("Could not create output directory: {parent:?}"))?;
     }
 
     let sorted_contours = contours.to_owned();
@@ -56,12 +56,12 @@ pub fn write_obj_mesh(
     }
 
     // Write material reference
-    writeln!(writer, "mtllib {}", mtl_filename)?;
+    writeln!(writer, "mtllib {mtl_filename}")?;
     writeln!(writer, "usemtl displacement_material")?;
 
     // Write UV coordinates for original vertices
     for (u, v) in uv_coords {
-        writeln!(writer, "vt {} {}", u, v)?;
+        writeln!(writer, "vt {u} {v}")?;
     }
 
     // Compute and write normals for original vertices
@@ -89,15 +89,14 @@ pub fn write_obj_mesh(
             let v1 = offset1 + j;
             let v2 = offset1 + j_next;
             let v3 = offset2 + j;
-            writeln!(writer, "f {0}/{0}/{0} {1}/{1}/{1} {2}/{2}/{2}", v1, v2, v3)?;
+            writeln!(writer, "f {v1}/{v1}/{v1} {v2}/{v2}/{v2} {v3}/{v3}/{v3}")?;
 
             let v1_t2 = offset2 + j;
             let v2_t2 = offset1 + j_next;
             let v3_t2 = offset2 + j_next;
             writeln!(
                 writer,
-                "f {0}/{0}/{0} {1}/{1}/{1} {2}/{2}/{2}",
-                v1_t2, v2_t2, v3_t2
+                "f {v1_t2}/{v1_t2}/{v1_t2} {v2_t2}/{v2_t2}/{v2_t2} {v3_t2}/{v3_t2}/{v3_t2}"
             )?;
         }
     }
@@ -161,9 +160,9 @@ fn close_end(
         let v3 = centroid_vertex_index;
 
         if reverse_winding {
-            writeln!(writer, "f {0}/{0}/{0} {1}/{1}/{1} {2}/{2}/{2}", v3, v2, v1)?;
+            writeln!(writer, "f {v3}/{v3}/{v3} {v2}/{v2}/{v2} {v1}/{v1}/{v1}")?;
         } else {
-            writeln!(writer, "f {0}/{0}/{0} {1}/{1}/{1} {2}/{2}/{2}", v1, v2, v3)?;
+            writeln!(writer, "f {v1}/{v1}/{v1} {v2}/{v2}/{v2} {v3}/{v3}/{v3}")?;
         }
     }
     Ok(())
@@ -183,7 +182,7 @@ pub fn write_obj_mesh_without_uv(
         mtl_filename,
         watertight,
     )
-    .map_err(|e| anyhow!("Failed to write OBJ mesh without UV: {}", e))
+    .map_err(|e| anyhow!("Failed to write OBJ mesh without UV: {e}"))
 }
 
 impl ContourType {
@@ -251,10 +250,8 @@ pub fn write_geometry_vec_to_obj(
 ) -> anyhow::Result<()> {
     // Create owned versions for thread-safe capture
     let output_dir = output_dir.as_ref();
-    std::fs::create_dir_all(output_dir).context(format!(
-        "Could not create output directory: {:?}",
-        output_dir
-    ))?;
+    std::fs::create_dir_all(output_dir)
+        .context(format!("Could not create output directory: {output_dir:?}"))?;
 
     let case_name = case_name.to_owned();
     let total = geometries.len();
@@ -275,7 +272,7 @@ pub fn write_geometry_vec_to_obj(
 
             let contours = contour_type.get_contours(geometry);
             write_obj_mesh(&contours, mesh_uv, obj_path_str, &mtl_name, watertight)
-                .map_err(|e| anyhow!("Failed [{}]: {}", obj_name, e))
+                .map_err(|e| anyhow!("Failed [{obj_name}]: {e}"))
         })
         .collect();
 
@@ -288,7 +285,7 @@ pub fn write_geometry_vec_to_obj(
         success_count,
         total,
         if fail_count > 0 {
-            format!(", {} failures", fail_count)
+            format!(", {fail_count} failures")
         } else {
             String::new()
         }
@@ -302,7 +299,7 @@ pub fn write_geometry_vec_to_obj(
             .map(|e| e.to_string())
             .collect::<Vec<_>>()
             .join("\n");
-        bail!("Some .obj writes failed:\n{}", errors);
+        bail!("Some .obj writes failed:\n{errors}");
     }
 
     Ok(())

--- a/src/intravascular/processing/align_between.rs
+++ b/src/intravascular/processing/align_between.rs
@@ -378,13 +378,11 @@ mod align_between_tests {
         // Verify alignment precision
         assert!(
             max_error < 0.01,
-            "Maximum alignment error {} exceeds threshold",
-            max_error
+            "Maximum alignment error {max_error} exceeds threshold"
         );
         assert!(
             avg_error < 0.001,
-            "Average alignment error {} exceeds threshold",
-            avg_error
+            "Average alignment error {avg_error} exceeds threshold"
         );
 
         Ok(())

--- a/src/intravascular/processing/align_within.rs
+++ b/src/intravascular/processing/align_within.rs
@@ -380,7 +380,7 @@ pub fn fill_holes(geometry: &mut Geometry) -> anyhow::Result<Geometry> {
         return Err(anyhow!("Baseline spacing is zero or too small to decide."));
     }
 
-    println!("⚠️\tHole detected! Attempting to fix using Geometry::insert_frame(...) (baseline spacing = {:.3})", baseline);
+    println!("⚠️\tHole detected! Attempting to fix using Geometry::insert_frame(...) (baseline spacing = {baseline:.3})");
 
     let mut i: usize = 1;
     while i < geometry.frames.len() {
@@ -823,8 +823,8 @@ mod align_within_tests {
         );
         for (i, log) in logs.iter().enumerate() {
             let idx = i as f64 + 1.0;
-            let expected_tx = -1.0 * idx;
-            let expected_ty = -1.0 * idx;
+            let expected_tx = -idx;
+            let expected_ty = -idx;
             assert_relative_eq!(log.rot_deg, -15.0, epsilon = 1e-6);
             assert_relative_eq!(log.tx, expected_tx, epsilon = 1e-6);
             assert_relative_eq!(log.ty, expected_ty, epsilon = 1e-6);
@@ -836,7 +836,7 @@ mod align_within_tests {
     fn test_simple_geometry_middle_ref() -> anyhow::Result<()> {
         let mut dummy = dummy_geometry_center_reference();
         let ref_frame_idx = dummy.find_ref_frame_idx();
-        println!("Reference idx: {:?}", ref_frame_idx);
+        println!("Reference idx: {ref_frame_idx:?}");
 
         for frame in dummy.frames.iter() {
             println!("Frame {:?}:\nz.position:{:?}, point0 x: {:?}, point0 y: {:?}, point0 z: {:?}, ref_point present?: {:?}",

--- a/src/intravascular/processing/postprocessing.rs
+++ b/src/intravascular/processing/postprocessing.rs
@@ -615,7 +615,7 @@ mod tests {
 
         // The current implementation uses absolute difference, so these should be different
         // If the test fails, we need to check the actual implementation
-        println!("same: {}, diff_a: {}, diff_b: {}", same, diff_a, diff_b);
+        println!("same: {same}, diff_a: {diff_a}, diff_b: {diff_b}");
         // Just test that we get some values back
         assert!(diff_a > 0.0);
         assert!(diff_b > 0.0);

--- a/src/intravascular/processing/preprocessing.rs
+++ b/src/intravascular/processing/preprocessing.rs
@@ -130,10 +130,7 @@ pub fn prepare_n_geometries(
                     n_points,
                 )
                 .with_context(|| {
-                    format!(
-                        "Failed to build geometry for Pair with diastole={}",
-                        diastole
-                    )
+                    format!("Failed to build geometry for Pair with diastole={diastole}")
                 })?;
                 geometries.push(geom);
             }
@@ -193,8 +190,7 @@ pub fn prepare_n_geometries(
                     )
                     .with_context(|| {
                         format!(
-                            "Failed to build geometry for Full from path with diastole={}",
-                            diastole
+                            "Failed to build geometry for Full from path with diastole={diastole}"
                         )
                     })?;
                     geometries.push(geom);
@@ -421,7 +417,7 @@ mod preprocessing_tests {
 
         assert_eq!(geometry.len(), 4);
         for (i, geom) in geometry.iter().enumerate() {
-            assert_eq!(geom.label, format!("test_{}", i));
+            assert_eq!(geom.label, format!("test_{i}"));
         }
         Ok(())
     }

--- a/src/intravascular/to_object/mod.rs
+++ b/src/intravascular/to_object/mod.rs
@@ -52,10 +52,7 @@ pub fn process_case(
                 watertight,
             )?;
         } else {
-            eprintln!(
-                "Warning: No UV coordinates found for contour type {:?}",
-                contour_type
-            );
+            eprintln!("Warning: No UV coordinates found for contour type {contour_type:?}");
         }
     }
 
@@ -77,20 +74,17 @@ pub fn write_single_geometry(
 ) -> anyhow::Result<Geometry> {
     std::fs::create_dir_all(output_dir)?;
 
-    println!("\nSaving files for '{}' to '{}'", case_name, output_dir);
+    println!("\nSaving files for '{case_name}' to '{output_dir}'");
     for &contour_type in contour_types {
         let contours = contour_type.get_contours(&geometry);
         if contours.is_empty() {
-            eprintln!(
-                "Warning: No contours found for type {:?}, skipping",
-                contour_type
-            );
+            eprintln!("Warning: No contours found for type {contour_type:?}, skipping");
             continue;
         }
 
         let type_name = format!("{contour_type}").to_lowercase();
-        let obj_filename = format!("{}_{}.obj", case_name, type_name);
-        let mtl_filename = format!("{}_{}.mtl", case_name, type_name);
+        let obj_filename = format!("{case_name}_{type_name}.obj");
+        let mtl_filename = format!("{case_name}_{type_name}.mtl");
         let obj_path = Path::new(output_dir).join(&obj_filename);
         let mtl_path = Path::new(output_dir).join(&mtl_filename);
 

--- a/src/intravascular/to_object/write_mtl.rs
+++ b/src/intravascular/to_object/write_mtl.rs
@@ -101,7 +101,7 @@ fn write_displacement_texture(
 
         // Save displacement texture
         let type_name = get_contour_type_name(contour_type);
-        let tex_filename = format!("{}_{:03}_{}.png", type_name, i, case_name);
+        let tex_filename = format!("{type_name}_{i:03}_{case_name}.png");
         let texture_path = Path::new(output_dir).join(&tex_filename);
 
         if let Err(e) = create_displacement_texture(
@@ -111,24 +111,20 @@ fn write_displacement_texture(
             max_disp,
             texture_path.to_str().unwrap(),
         ) {
-            eprintln!(
-                "Failed to create displacement texture for {}: {}",
-                type_name, e
-            );
+            eprintln!("Failed to create displacement texture for {type_name}: {e}");
             continue;
         }
 
         // Write MTL file
-        let mtl_filename = format!("{}_{:03}_{}.mtl", type_name, i, case_name);
+        let mtl_filename = format!("{type_name}_{i:03}_{case_name}.mtl");
         let mtl_path = Path::new(output_dir).join(&mtl_filename);
 
         if let Ok(mut mtl_file) = File::create(&mtl_path) {
             writeln!(
                 mtl_file,
-                "newmtl displacement_material\nKa 1 1 1\nKd 1 1 1\nmap_Kd {}",
-                tex_filename
+                "newmtl displacement_material\nKa 1 1 1\nKd 1 1 1\nmap_Kd {tex_filename}"
             )
-            .unwrap_or_else(|e| eprintln!("Failed to write MTL file: {}", e));
+            .unwrap_or_else(|e| eprintln!("Failed to write MTL file: {e}"));
         }
     }
 
@@ -164,7 +160,7 @@ fn write_black_texture(
 
         // Save black texture
         let type_name = get_contour_type_name(contour_type);
-        let tex_filename = format!("{}_{:03}_{}.png", type_name, i, case_name);
+        let tex_filename = format!("{type_name}_{i:03}_{case_name}.png");
         let texture_path = Path::new(output_dir).join(&tex_filename);
 
         if let Err(e) = create_black_texture(
@@ -172,21 +168,20 @@ fn write_black_texture(
             texture_height,
             texture_path.to_str().unwrap(),
         ) {
-            eprintln!("Failed to create black texture for {}: {}", type_name, e);
+            eprintln!("Failed to create black texture for {type_name}: {e}");
             continue;
         }
 
         // Write MTL file
-        let mtl_filename = format!("{}_{:03}_{}.mtl", type_name, i, case_name);
+        let mtl_filename = format!("{type_name}_{i:03}_{case_name}.mtl");
         let mtl_path = Path::new(output_dir).join(&mtl_filename);
 
         if let Ok(mut mtl_file) = File::create(&mtl_path) {
             writeln!(
                 mtl_file,
-                "newmtl black_material\nKa 0 0 0\nKd 0 0 0\nmap_Kd {}",
-                tex_filename
+                "newmtl black_material\nKa 0 0 0\nKd 0 0 0\nmap_Kd {tex_filename}"
             )
-            .unwrap_or_else(|e| eprintln!("Failed to write MTL file: {}", e));
+            .unwrap_or_else(|e| eprintln!("Failed to write MTL file: {e}"));
         }
     }
 
@@ -222,7 +217,7 @@ fn write_transparent_texture(
 
         // Save transparent texture
         let type_name = get_contour_type_name(contour_type);
-        let tex_filename = format!("{}_{:03}_{}.png", type_name, i, case_name);
+        let tex_filename = format!("{type_name}_{i:03}_{case_name}.png");
         let texture_path = Path::new(output_dir).join(&tex_filename);
 
         if let Err(e) = create_transparent_texture(
@@ -231,24 +226,20 @@ fn write_transparent_texture(
             0.7, // alpha value
             texture_path.to_str().unwrap(),
         ) {
-            eprintln!(
-                "Failed to create transparent texture for {}: {}",
-                type_name, e
-            );
+            eprintln!("Failed to create transparent texture for {type_name}: {e}");
             continue;
         }
 
         // Write MTL file
-        let mtl_filename = format!("{}_{:03}_{}.mtl", type_name, i, case_name);
+        let mtl_filename = format!("{type_name}_{i:03}_{case_name}.mtl");
         let mtl_path = Path::new(output_dir).join(&mtl_filename);
 
         if let Ok(mut mtl_file) = File::create(&mtl_path) {
             writeln!(
                 mtl_file,
-                "newmtl transparent_material\nKa 0 0 0\nKd 0 0 0\nmap_Kd {}",
-                tex_filename
+                "newmtl transparent_material\nKa 0 0 0\nKd 0 0 0\nmap_Kd {tex_filename}"
             )
-            .unwrap_or_else(|e| eprintln!("Failed to write MTL file: {}", e));
+            .unwrap_or_else(|e| eprintln!("Failed to write MTL file: {e}"));
         }
     }
 

--- a/src/intravascular/utils/general_utils.rs
+++ b/src/intravascular/utils/general_utils.rs
@@ -163,16 +163,16 @@ pub fn write_debug_obj_mesh(contours: &[Contour], filename: &str) -> Result<(), 
             let v1 = offset1 + j;
             let v2 = offset1 + j_next;
             let v3 = offset2 + j;
-            writeln!(writer, "f {} {} {}", v1, v2, v3)?;
+            writeln!(writer, "f {v1} {v2} {v3}")?;
 
             // Second triangle
             let v4 = offset2 + j;
             let v5 = offset1 + j_next;
             let v6 = offset2 + j_next;
-            writeln!(writer, "f {} {} {}", v4, v5, v6)?;
+            writeln!(writer, "f {v4} {v5} {v6}")?;
         }
     }
 
-    println!("Debug OBJ mesh written to {}", filename);
+    println!("Debug OBJ mesh written to {filename}");
     Ok(())
 }

--- a/src/intravascular/utils/test_utils.rs
+++ b/src/intravascular/utils/test_utils.rs
@@ -434,7 +434,7 @@ mod test_utils_tests {
     #[test]
     fn test_dummy_geometry_ref_middle() {
         let geometry = dummy_geometry_center_reference();
-        println!("Geometry: {:?}", geometry);
+        println!("Geometry: {geometry:?}");
         assert_eq!(geometry.frames.len(), 6);
         assert!(geometry.frames[0].reference_point.is_none());
 

--- a/tests/test_ccta.py
+++ b/tests/test_ccta.py
@@ -10,6 +10,7 @@ Covers:
                   _rotate_to_nearest_iv, _fix_ring_direction_by_distance,
                   _stitch_boundary_ring
 """
+
 from __future__ import annotations
 
 import importlib
@@ -19,7 +20,10 @@ import pytest
 import trimesh
 
 from multimodars import PyContourPoint
-from multimodars.ccta.fixing_functions import manual_hole_fill, postprocess_stitched_mesh
+from multimodars.ccta.fixing_functions import (
+    manual_hole_fill,
+    postprocess_stitched_mesh,
+)
 from multimodars.ccta.labeling import (
     _find_aortic_points,
     _find_faces_for_points,
@@ -40,10 +44,10 @@ from multimodars.ccta.manipulating import (
     sync_results_to_mesh,
 )
 
-
 # ---------------------------------------------------------------------------
 # Shared mesh factories
 # ---------------------------------------------------------------------------
+
 
 def _make_grid_mesh() -> trimesh.Trimesh:
     """3x3 grid (9 vertices, 8 triangular faces, z=0 plane).
@@ -108,6 +112,7 @@ def _make_iv_pts(coords) -> list[PyContourPoint]:
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def grid_mesh():
     return _make_grid_mesh()
@@ -124,9 +129,9 @@ def grid_results(grid_mesh):
     verts = [tuple(v) for v in grid_mesh.vertices]
     return {
         "mesh": grid_mesh,
-        "aorta_points": verts[6:9],   # vertices 6, 7, 8
-        "rca_points":   verts[0:3],   # vertices 0, 1, 2
-        "lca_points":   verts[3:6],   # vertices 3, 4, 5
+        "aorta_points": verts[6:9],  # vertices 6, 7, 8
+        "rca_points": verts[0:3],  # vertices 0, 1, 2
+        "lca_points": verts[3:6],  # vertices 3, 4, 5
         "rca_removed_points": [],
         "lca_removed_points": [],
     }
@@ -135,6 +140,7 @@ def grid_results(grid_mesh):
 # ===========================================================================
 # labeling._find_aortic_points
 # ===========================================================================
+
 
 class TestFindAorticPoints:
     def test_basic_set_difference(self, grid_mesh):
@@ -164,6 +170,7 @@ class TestFindAorticPoints:
 # labeling._find_faces_for_points
 # ===========================================================================
 
+
 class TestFindFacesForPoints:
     def test_corner_vertex_finds_its_face(self, grid_mesh):
         # vertex 0 = (0,0,0) belongs to face [0,1,3] → face index 0
@@ -191,6 +198,7 @@ class TestFindFacesForPoints:
 # labeling._prepare_faces_for_rust
 # ===========================================================================
 
+
 class TestPrepareFacesForRust:
     def test_all_faces_when_no_args(self, grid_mesh):
         rust_faces = _prepare_faces_for_rust(grid_mesh)
@@ -212,7 +220,9 @@ class TestPrepareFacesForRust:
 
     def test_subset_via_points(self, grid_mesh):
         # corner vertex 0 only in ~1 face, so subset < all
-        rust_faces = _prepare_faces_for_rust(grid_mesh, points=[(0.0, 0.0, 0.0)], tol=1e-6)
+        rust_faces = _prepare_faces_for_rust(
+            grid_mesh, points=[(0.0, 0.0, 0.0)], tol=1e-6
+        )
         assert 0 < len(rust_faces) < len(grid_mesh.faces)
 
     def test_empty_points_returns_all(self, grid_mesh):
@@ -224,6 +234,7 @@ class TestPrepareFacesForRust:
 # ===========================================================================
 # labeling._final_reclassification
 # ===========================================================================
+
 
 class TestFinalReclassification:
     # ------------------------------------------------------------------
@@ -311,15 +322,26 @@ class TestFinalReclassification:
         new = _final_reclassification(results)
         total = sum(
             len(new[k])
-            for k in ("aorta_points", "rca_points", "lca_points",
-                      "rca_removed_points", "lca_removed_points")
+            for k in (
+                "aorta_points",
+                "rca_points",
+                "lca_points",
+                "rca_removed_points",
+                "lca_removed_points",
+            )
         )
         assert total == len(grid_mesh.vertices)
 
     def test_returns_dict_with_required_keys(self, grid_results):
         new = _final_reclassification(grid_results)
-        for key in ("mesh", "aorta_points", "rca_points", "lca_points",
-                    "rca_removed_points", "lca_removed_points"):
+        for key in (
+            "mesh",
+            "aorta_points",
+            "rca_points",
+            "lca_points",
+            "rca_removed_points",
+            "lca_removed_points",
+        ):
             assert key in new
 
 
@@ -327,11 +349,12 @@ class TestFinalReclassification:
 # fixing_functions.manual_hole_fill
 # ===========================================================================
 
+
 class TestManualHoleFill:
     def test_adds_faces_to_open_mesh(self):
         """Box with top cap removed gets new faces from hole fill."""
         box = trimesh.creation.box()
-        top_mask = box.face_normals[:, 2] < 0.9   # keep all non-top faces
+        top_mask = box.face_normals[:, 2] < 0.9  # keep all non-top faces
         holed = trimesh.Trimesh(
             vertices=box.vertices,
             faces=box.faces[top_mask],
@@ -358,6 +381,7 @@ class TestManualHoleFill:
 # fixing_functions.postprocess_stitched_mesh
 # ===========================================================================
 
+
 class TestPostprocessStitchedMesh:
     def test_passthrough_when_disabled(self, grid_mesh):
         result = postprocess_stitched_mesh(grid_mesh, postprocessing=False)
@@ -374,25 +398,34 @@ class TestPostprocessStitchedMesh:
 # manipulating.remove_labeled_points_from_mesh
 # ===========================================================================
 
+
 class TestRemoveLabeledPoints:
     def test_removes_vertices_from_mesh(self, grid_results):
-        updated = remove_labeled_points_from_mesh(grid_results, region_keys="rca_points")
+        updated = remove_labeled_points_from_mesh(
+            grid_results, region_keys="rca_points"
+        )
         new_verts = {tuple(v) for v in updated["mesh"].vertices}
         rca_set = {(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (2.0, 0.0, 0.0)}
         assert rca_set.isdisjoint(new_verts)
 
     def test_boundary_points_populated(self, grid_results):
-        updated = remove_labeled_points_from_mesh(grid_results, region_keys="rca_points")
+        updated = remove_labeled_points_from_mesh(
+            grid_results, region_keys="rca_points"
+        )
         assert len(updated["boundary_points"]) > 0
 
     def test_removed_key_cleared(self, grid_results):
-        updated = remove_labeled_points_from_mesh(grid_results, region_keys="rca_points")
+        updated = remove_labeled_points_from_mesh(
+            grid_results, region_keys="rca_points"
+        )
         assert updated["rca_points"] == []
 
     def test_empty_region_is_noop(self, grid_results):
         grid_results["rca_points"] = []
         n_before = len(grid_results["mesh"].vertices)
-        updated = remove_labeled_points_from_mesh(grid_results, region_keys="rca_points")
+        updated = remove_labeled_points_from_mesh(
+            grid_results, region_keys="rca_points"
+        )
         assert len(updated["mesh"].vertices) == n_before
 
     def test_multiple_keys(self, grid_results):
@@ -405,7 +438,9 @@ class TestRemoveLabeledPoints:
         assert len(updated["mesh"].vertices) == 3
 
     def test_remaining_lists_consistent_with_new_mesh(self, grid_results):
-        updated = remove_labeled_points_from_mesh(grid_results, region_keys="rca_points")
+        updated = remove_labeled_points_from_mesh(
+            grid_results, region_keys="rca_points"
+        )
         new_verts = {tuple(v) for v in updated["mesh"].vertices}
         for key in ("aorta_points", "lca_points"):
             for pt in updated.get(key, []):
@@ -414,14 +449,20 @@ class TestRemoveLabeledPoints:
     def test_string_or_list_region_keys(self, grid_results):
         """String and single-item list should produce identical results."""
         import copy
-        r1 = remove_labeled_points_from_mesh(copy.deepcopy(grid_results), region_keys="rca_points")
-        r2 = remove_labeled_points_from_mesh(copy.deepcopy(grid_results), region_keys=["rca_points"])
+
+        r1 = remove_labeled_points_from_mesh(
+            copy.deepcopy(grid_results), region_keys="rca_points"
+        )
+        r2 = remove_labeled_points_from_mesh(
+            copy.deepcopy(grid_results), region_keys=["rca_points"]
+        )
         assert len(r1["mesh"].vertices) == len(r2["mesh"].vertices)
 
 
 # ===========================================================================
 # manipulating.keep_labeled_points_from_mesh
 # ===========================================================================
+
 
 class TestKeepLabeledPoints:
     def test_mesh_vertex_count_reduced(self, grid_results):
@@ -450,6 +491,7 @@ class TestKeepLabeledPoints:
 # manipulating.sync_results_to_mesh
 # ===========================================================================
 
+
 class TestSyncResultsToMesh:
     def test_mesh_replaced(self, grid_results, grid_mesh):
         new_mesh = trimesh.Trimesh(
@@ -463,7 +505,9 @@ class TestSyncResultsToMesh:
     def test_coordinate_lists_updated(self, grid_results, grid_mesh):
         shift = np.array([10.0, 0.0, 0.0])
         new_verts = grid_mesh.vertices.copy() + shift
-        new_mesh = trimesh.Trimesh(vertices=new_verts, faces=grid_mesh.faces, process=False)
+        new_mesh = trimesh.Trimesh(
+            vertices=new_verts, faces=grid_mesh.faces, process=False
+        )
         updated = sync_results_to_mesh(grid_results, grid_mesh, new_mesh)
         for pt in updated["rca_points"]:
             assert pt[0] >= 10.0
@@ -482,6 +526,7 @@ class TestSyncResultsToMesh:
 # ===========================================================================
 # manipulating.order_points_list
 # ===========================================================================
+
 
 class TestOrderPointsList:
     def test_single_point_returns_same(self, hex_fan_mesh):
@@ -519,6 +564,7 @@ class TestOrderPointsList:
 # manipulating.scale_region_centerline_morphing
 # ===========================================================================
 
+
 class TestScaleRegionCenterlineMorphing:
     def test_no_matching_vertices_returns_copy(self, grid_mesh, capsys):
         """Passing points not on the mesh triggers the warning path (no Rust call)."""
@@ -538,6 +584,7 @@ class TestScaleRegionCenterlineMorphing:
 # ===========================================================================
 # manipulating._rotate_to_nearest_iv
 # ===========================================================================
+
 
 class TestRotateToNearestIv:
     def test_rotates_to_nearest_iv_point(self):
@@ -571,6 +618,7 @@ class TestRotateToNearestIv:
 # ===========================================================================
 # manipulating._fix_ring_direction_by_distance
 # ===========================================================================
+
 
 class TestFixRingDirectionByDistance:
     def test_correct_direction_unchanged(self):
@@ -614,10 +662,13 @@ class TestFixRingDirectionByDistance:
 # manipulating._stitch_boundary_ring
 # ===========================================================================
 
+
 class TestStitchBoundaryRing:
     def _ring_pts(self, n: int, radius: float = 1.0, z: float = 0.0):
         angles = np.linspace(0, 2 * np.pi, n, endpoint=False)
-        return [(radius * float(np.cos(a)), radius * float(np.sin(a)), z) for a in angles]
+        return [
+            (radius * float(np.cos(a)), radius * float(np.sin(a)), z) for a in angles
+        ]
 
     def test_creates_trimesh(self):
         n_b, n_iv = 6, 12
@@ -653,7 +704,9 @@ class TestStitchBoundaryRing:
         boundary_pts = self._ring_pts(n_b, z=0.0)
         iv_pts = _make_iv_pts(self._ring_pts(n_iv, radius=1.2, z=0.0))
         outward = np.array([0.0, 0.0, 1.0])
-        patch = _stitch_boundary_ring(boundary_pts, iv_pts, n_iv // n_b, outward_direction=outward)
+        patch = _stitch_boundary_ring(
+            boundary_pts, iv_pts, n_iv // n_b, outward_direction=outward
+        )
         valid = ~np.isnan(patch.face_normals).any(axis=1)
         if valid.any():
             avg_normal = patch.face_normals[valid].mean(axis=0)
@@ -663,6 +716,7 @@ class TestStitchBoundaryRing:
 # ---------------------------------------------------------------------------
 # Additional mesh factories for ostium tests
 # ---------------------------------------------------------------------------
+
 
 def _make_concentric_ring_mesh() -> trimesh.Trimesh:
     """Three concentric rings of 4 vertices each in the z=0 plane.
@@ -682,10 +736,14 @@ def _make_concentric_ring_mesh() -> trimesh.Trimesh:
     faces = []
     for i in range(4):
         j = (i + 1) % 4
-        faces.extend([
-            [i, j, i + 4], [j, j + 4, i + 4],
-            [i + 4, j + 4, i + 8], [j + 4, j + 8, i + 8],
-        ])
+        faces.extend(
+            [
+                [i, j, i + 4],
+                [j, j + 4, i + 4],
+                [i + 4, j + 4, i + 8],
+                [j + 4, j + 8, i + 8],
+            ]
+        )
     return trimesh.Trimesh(vertices=verts, faces=np.array(faces), process=False)
 
 
@@ -714,6 +772,7 @@ def _make_annular_xz_mesh() -> trimesh.Trimesh:
 # manipulating._clamp_to_plane
 # ===========================================================================
 
+
 class TestClampToPlane:
     """Plane: z=0, normal=[0,0,1]. Correct side is z>0."""
 
@@ -737,15 +796,15 @@ class TestClampToPlane:
         """Wrong-side point clamped to plane then pushed 1 mm past it."""
         pts = [(0.0, 0.0, 2.0), (0.0, 0.0, -0.5)]
         result = _clamp_to_plane(pts, self._origin, self._normal, overshoot=1.0)
-        assert result[0][2] == pytest.approx(2.0)   # already beyond overshoot
-        assert result[1][2] == pytest.approx(1.0)   # clamped to 0, then pushed to 1
+        assert result[0][2] == pytest.approx(2.0)  # already beyond overshoot
+        assert result[1][2] == pytest.approx(1.0)  # clamped to 0, then pushed to 1
 
     def test_overshoot_pushes_near_plane_correct_side_point(self):
         """Correct-side point within overshoot distance is pushed to that distance."""
         pts = [(0.0, 0.0, 3.0), (0.0, 0.0, 0.3)]
         result = _clamp_to_plane(pts, self._origin, self._normal, overshoot=1.0)
-        assert result[0][2] == pytest.approx(3.0)   # far enough, unchanged
-        assert result[1][2] == pytest.approx(1.0)   # 0.3 < 1.0, pushed
+        assert result[0][2] == pytest.approx(3.0)  # far enough, unchanged
+        assert result[1][2] == pytest.approx(1.0)  # 0.3 < 1.0, pushed
 
     def test_all_points_satisfy_minimum_gap(self):
         pts = [(float(i), 0.0, float(i % 5) * 0.2 - 0.2) for i in range(10)]
@@ -762,6 +821,7 @@ class TestClampToPlane:
 # ===========================================================================
 # manipulating._enforce_layer_gap_from_plane
 # ===========================================================================
+
 
 class TestEnforceLayerGapFromPlane:
     """Uses the concentric-ring mesh (z=0 plane, IV normal=[0,0,1]).
@@ -809,7 +869,9 @@ class TestEnforceLayerGapFromPlane:
         result = _enforce_layer_gap_from_plane(
             mesh, self._seeds, self._origin, self._normal, layer_step_mm=0.1
         )
-        np.testing.assert_allclose(result.vertices[:, 2], mesh.vertices[:, 2], atol=1e-10)
+        np.testing.assert_allclose(
+            result.vertices[:, 2], mesh.vertices[:, 2], atol=1e-10
+        )
 
     def test_returns_trimesh(self):
         mesh = _make_concentric_ring_mesh()
@@ -822,6 +884,7 @@ class TestEnforceLayerGapFromPlane:
 # ===========================================================================
 # manipulating._prepare_prox_dist_boundary_pts
 # ===========================================================================
+
 
 class TestPrepareProxDistBoundaryPts:
     """Two sub-cases: non-anomalous (proximal_is_ostium=False) and anomalous."""
@@ -837,7 +900,7 @@ class TestPrepareProxDistBoundaryPts:
         outer = [tuple(mesh.vertices[i]) for i in range(6)]
 
         # Put three outer vertices near prox_centroid, three near dist_centroid
-        prox_centroid = (1.0, 0.0, 0.0)   # near vertex 0
+        prox_centroid = (1.0, 0.0, 0.0)  # near vertex 0
         dist_centroid = (-1.0, 0.0, 0.0)  # near vertex 3
         results = {"boundary_points": outer}
 
@@ -885,7 +948,9 @@ class TestPrepareProxDistBoundaryPts:
     def _make_iv_frame_xy(self, n: int = 8, radius: float = 0.5):
         """IV lumen ring in the XY plane (z=0), normal ≈ [0,0,1]."""
         angles = np.linspace(0, 2 * np.pi, n, endpoint=False)
-        coords = [(radius * float(np.cos(a)), radius * float(np.sin(a)), 0.0) for a in angles]
+        coords = [
+            (radius * float(np.cos(a)), radius * float(np.sin(a)), 0.0) for a in angles
+        ]
         return _make_iv_pts(coords)
 
     def test_anomalous_prox_boundary_pts_respect_overshoot(self):
@@ -898,7 +963,10 @@ class TestPrepareProxDistBoundaryPts:
         dist_centroid = (100.0, 0.0, 0.0)  # all boundary pts go to prox
 
         prox_pts, _, _ = _prepare_prox_dist_boundary_pts(
-            mesh, results, prox_centroid, dist_centroid,
+            mesh,
+            results,
+            prox_centroid,
+            dist_centroid,
             proximal_is_ostium=True,
             proximal_iv_frame_pts=iv_pts,
             clamp_overshoot=overshoot,
@@ -919,7 +987,10 @@ class TestPrepareProxDistBoundaryPts:
         dist_centroid = (100.0, 0.0, 0.0)
 
         prox_pts, _, _ = _prepare_prox_dist_boundary_pts(
-            mesh, results, prox_centroid, dist_centroid,
+            mesh,
+            results,
+            prox_centroid,
+            dist_centroid,
             proximal_is_ostium=True,
             proximal_iv_frame_pts=iv_pts,
         )
@@ -934,7 +1005,10 @@ class TestPrepareProxDistBoundaryPts:
         dist_centroid = (100.0, 0.0, 0.0)
 
         _, _, updated_mesh = _prepare_prox_dist_boundary_pts(
-            mesh, results, prox_centroid, dist_centroid,
+            mesh,
+            results,
+            prox_centroid,
+            dist_centroid,
             proximal_is_ostium=True,
             proximal_iv_frame_pts=iv_pts,
         )
@@ -943,12 +1017,12 @@ class TestPrepareProxDistBoundaryPts:
         # Vertices with x != 0 in the IV-plane projection are the ones that move.
         moved = False
         for i in range(8, 16):
-            old_r = np.linalg.norm(mesh.vertices[i, [0, 1]])   # XY radius
+            old_r = np.linalg.norm(mesh.vertices[i, [0, 1]])  # XY radius
             new_r = np.linalg.norm(updated_mesh.vertices[i, [0, 1]])
             if old_r > 1e-6:  # skip vertices projecting to IV centre
-                assert new_r >= old_r - 1e-6, (
-                    f"Vertex {i} moved inward: {old_r:.4f} → {new_r:.4f}"
-                )
+                assert (
+                    new_r >= old_r - 1e-6
+                ), f"Vertex {i} moved inward: {old_r:.4f} → {new_r:.4f}"
                 if new_r > old_r + 1e-6:
                     moved = True
         assert moved, "Expected at least some outer-ring vertices to move outward"

--- a/tests/test_ccta.py
+++ b/tests/test_ccta.py
@@ -27,7 +27,10 @@ from multimodars.ccta.labeling import (
     _prepare_faces_for_rust,
 )
 from multimodars.ccta.manipulating import (
+    _clamp_to_plane,
+    _enforce_layer_gap_from_plane,
     _fix_ring_direction_by_distance,
+    _prepare_prox_dist_boundary_pts,
     _rotate_to_nearest_iv,
     _stitch_boundary_ring,
     keep_labeled_points_from_mesh,
@@ -655,3 +658,311 @@ class TestStitchBoundaryRing:
         if valid.any():
             avg_normal = patch.face_normals[valid].mean(axis=0)
             assert np.dot(avg_normal, outward) > 0
+
+
+# ---------------------------------------------------------------------------
+# Additional mesh factories for ostium tests
+# ---------------------------------------------------------------------------
+
+def _make_concentric_ring_mesh() -> trimesh.Trimesh:
+    """Three concentric rings of 4 vertices each in the z=0 plane.
+
+    Ring A (inner, radius 1): indices 0-3
+    Ring B (middle, radius 2): indices 4-7
+    Ring C (outer, radius 3): indices 8-11
+
+    Faces connect adjacent rings so adjacency map gives
+    A-neighbours = B and B-neighbours = C.
+    """
+    angles = [0.0, np.pi / 2, np.pi, 3 * np.pi / 2]
+    ring_a = [(np.cos(a), np.sin(a), 0.0) for a in angles]
+    ring_b = [(2.0 * np.cos(a), 2.0 * np.sin(a), 0.0) for a in angles]
+    ring_c = [(3.0 * np.cos(a), 3.0 * np.sin(a), 0.0) for a in angles]
+    verts = np.array(ring_a + ring_b + ring_c, dtype=float)
+    faces = []
+    for i in range(4):
+        j = (i + 1) % 4
+        faces.extend([
+            [i, j, i + 4], [j, j + 4, i + 4],
+            [i + 4, j + 4, i + 8], [j + 4, j + 8, i + 8],
+        ])
+    return trimesh.Trimesh(vertices=verts, faces=np.array(faces), process=False)
+
+
+def _make_annular_xz_mesh() -> trimesh.Trimesh:
+    """Annular mesh lying in the XZ plane (y=0).
+
+    Inner ring (radius 1, 8 verts): indices 0-7  — these become boundary_points.
+    Outer ring (radius 2, 8 verts): indices 8-15 — second aortic layer.
+
+    The ring plane has normal [0,1,0]; the IV ring (XY plane) has normal [0,0,1].
+    The angle between them is 90°, so the anomalous clamping path is triggered.
+    """
+    n = 8
+    angles = np.linspace(0, 2 * np.pi, n, endpoint=False)
+    inner = np.column_stack([np.cos(angles), np.zeros(n), np.sin(angles)])
+    outer = np.column_stack([2.0 * np.cos(angles), np.zeros(n), 2.0 * np.sin(angles)])
+    verts = np.vstack([inner, outer])
+    faces = []
+    for i in range(n):
+        j = (i + 1) % n
+        faces.extend([[i, j, i + n], [j, j + n, i + n]])
+    return trimesh.Trimesh(vertices=verts, faces=np.array(faces), process=False)
+
+
+# ===========================================================================
+# manipulating._clamp_to_plane
+# ===========================================================================
+
+class TestClampToPlane:
+    """Plane: z=0, normal=[0,0,1]. Correct side is z>0."""
+
+    _origin = np.array([0.0, 0.0, 0.0])
+    _normal = np.array([0.0, 0.0, 1.0])
+
+    def test_wrong_side_point_projected_onto_plane(self):
+        pts = [(0.0, 0.0, 1.0), (1.0, 0.0, 1.0), (0.5, 0.0, -0.5)]
+        result = _clamp_to_plane(pts, self._origin, self._normal, overshoot=0.0)
+        assert result[2][2] == pytest.approx(0.0, abs=1e-10)
+        assert result[0][2] == pytest.approx(1.0)
+        assert result[1][2] == pytest.approx(1.0)
+
+    def test_correct_side_points_unchanged_without_overshoot(self):
+        pts = [(0.0, 0.0, 0.5), (1.0, 0.0, 1.5), (0.0, 1.0, 2.0)]
+        result = _clamp_to_plane(pts, self._origin, self._normal, overshoot=0.0)
+        for orig, res in zip(pts, result):
+            assert res == pytest.approx(orig)
+
+    def test_overshoot_pushes_wrong_side_past_plane(self):
+        """Wrong-side point clamped to plane then pushed 1 mm past it."""
+        pts = [(0.0, 0.0, 2.0), (0.0, 0.0, -0.5)]
+        result = _clamp_to_plane(pts, self._origin, self._normal, overshoot=1.0)
+        assert result[0][2] == pytest.approx(2.0)   # already beyond overshoot
+        assert result[1][2] == pytest.approx(1.0)   # clamped to 0, then pushed to 1
+
+    def test_overshoot_pushes_near_plane_correct_side_point(self):
+        """Correct-side point within overshoot distance is pushed to that distance."""
+        pts = [(0.0, 0.0, 3.0), (0.0, 0.0, 0.3)]
+        result = _clamp_to_plane(pts, self._origin, self._normal, overshoot=1.0)
+        assert result[0][2] == pytest.approx(3.0)   # far enough, unchanged
+        assert result[1][2] == pytest.approx(1.0)   # 0.3 < 1.0, pushed
+
+    def test_all_points_satisfy_minimum_gap(self):
+        pts = [(float(i), 0.0, float(i % 5) * 0.2 - 0.2) for i in range(10)]
+        result = _clamp_to_plane(pts, self._origin, self._normal, overshoot=1.0)
+        assert all(p[2] >= 1.0 - 1e-9 for p in result)
+
+    def test_returns_list_of_3_tuples(self):
+        pts = [(0.0, 0.0, 1.0), (1.0, 0.0, 1.0)]
+        result = _clamp_to_plane(pts, self._origin, self._normal)
+        assert isinstance(result, list)
+        assert all(isinstance(p, tuple) and len(p) == 3 for p in result)
+
+
+# ===========================================================================
+# manipulating._enforce_layer_gap_from_plane
+# ===========================================================================
+
+class TestEnforceLayerGapFromPlane:
+    """Uses the concentric-ring mesh (z=0 plane, IV normal=[0,0,1]).
+
+    Seed = ring A (radius 1, indices 0-3).
+    IV centre = origin.  Radial push per ring = 0.1 mm.
+
+    Ring B (radius 2) → pushed 0.1 mm outward → expected radius 2.1.
+    Ring C (radius 3) → pushed 0.2 mm outward → expected radius 3.2.
+    """
+
+    _origin = np.array([0.0, 0.0, 0.0])
+    _normal = np.array([0.0, 0.0, 1.0])
+    _seeds = {0, 1, 2, 3}
+
+    def test_ring1_pushed_radially_outward(self):
+        mesh = _make_concentric_ring_mesh()
+        result = _enforce_layer_gap_from_plane(
+            mesh, self._seeds, self._origin, self._normal, layer_step_mm=0.1
+        )
+        for i in range(4, 8):
+            r = np.linalg.norm(result.vertices[i, :2])
+            assert r == pytest.approx(2.1, abs=1e-6)
+
+    def test_ring2_pushed_twice_the_step(self):
+        mesh = _make_concentric_ring_mesh()
+        result = _enforce_layer_gap_from_plane(
+            mesh, self._seeds, self._origin, self._normal, layer_step_mm=0.1
+        )
+        for i in range(8, 12):
+            r = np.linalg.norm(result.vertices[i, :2])
+            assert r == pytest.approx(3.2, abs=1e-6)
+
+    def test_seed_vertices_untouched(self):
+        mesh = _make_concentric_ring_mesh()
+        result = _enforce_layer_gap_from_plane(
+            mesh, self._seeds, self._origin, self._normal, layer_step_mm=0.1
+        )
+        for i in self._seeds:
+            np.testing.assert_allclose(result.vertices[i], mesh.vertices[i])
+
+    def test_z_coordinates_unchanged(self):
+        """Push is within the IV plane; z must not change."""
+        mesh = _make_concentric_ring_mesh()
+        result = _enforce_layer_gap_from_plane(
+            mesh, self._seeds, self._origin, self._normal, layer_step_mm=0.1
+        )
+        np.testing.assert_allclose(result.vertices[:, 2], mesh.vertices[:, 2], atol=1e-10)
+
+    def test_returns_trimesh(self):
+        mesh = _make_concentric_ring_mesh()
+        result = _enforce_layer_gap_from_plane(
+            mesh, self._seeds, self._origin, self._normal
+        )
+        assert isinstance(result, trimesh.Trimesh)
+
+
+# ===========================================================================
+# manipulating._prepare_prox_dist_boundary_pts
+# ===========================================================================
+
+class TestPrepareProxDistBoundaryPts:
+    """Two sub-cases: non-anomalous (proximal_is_ostium=False) and anomalous."""
+
+    # ------------------------------------------------------------------
+    # Non-anomalous: proximal path must be identical to the distal path
+    # (both use order_points_list — no projection, no clamping).
+    # ------------------------------------------------------------------
+
+    def test_non_anomalous_prox_same_as_distal_algo(self):
+        """proximal_is_ostium=False: prox result is just ordered by adjacency, same as dist."""
+        mesh = _make_hex_fan_mesh()
+        outer = [tuple(mesh.vertices[i]) for i in range(6)]
+
+        # Put three outer vertices near prox_centroid, three near dist_centroid
+        prox_centroid = (1.0, 0.0, 0.0)   # near vertex 0
+        dist_centroid = (-1.0, 0.0, 0.0)  # near vertex 3
+        results = {"boundary_points": outer}
+
+        prox_pts, dist_pts, _ = _prepare_prox_dist_boundary_pts(
+            mesh, results, prox_centroid, dist_centroid, proximal_is_ostium=False
+        )
+
+        # Sets must cover all outer vertices between them
+        assert set(prox_pts) | set(dist_pts) == set(outer)
+        # Both halves are non-empty
+        assert len(prox_pts) > 0 and len(dist_pts) > 0
+
+    def test_non_anomalous_prox_points_are_mesh_adjacent(self):
+        """Proximal points returned by non-anomalous path are edge-connected in order."""
+        from multimodars.multimodars import build_adjacency_map
+
+        mesh = _make_hex_fan_mesh()
+        outer = [tuple(mesh.vertices[i]) for i in range(6)]
+        prox_centroid = (1.0, 0.0, 0.0)
+        dist_centroid = (-100.0, 0.0, 0.0)  # all vertices are proximal
+        results = {"boundary_points": outer}
+
+        prox_pts, _, _ = _prepare_prox_dist_boundary_pts(
+            mesh, results, prox_centroid, dist_centroid, proximal_is_ostium=False
+        )
+
+        adj = build_adjacency_map(mesh.faces.tolist())
+        coord_to_idx = {tuple(v): i for i, v in enumerate(mesh.vertices)}
+        for k in range(len(prox_pts) - 1):
+            a = coord_to_idx[tuple(prox_pts[k])]
+            b = coord_to_idx[tuple(prox_pts[k + 1])]
+            assert b in adj.get(a, [])
+
+    # ------------------------------------------------------------------
+    # Anomalous: boundary ring in XZ plane (normal [0,1,0]),
+    # IV frame in XY plane (normal [0,0,1]).  Angle = 90° > 45° threshold
+    # → clamping + overshoot are applied.
+    # ------------------------------------------------------------------
+
+    def _make_anomalous_results(self):
+        mesh = _make_annular_xz_mesh()
+        inner = [tuple(mesh.vertices[i]) for i in range(8)]
+        return mesh, {"boundary_points": inner}
+
+    def _make_iv_frame_xy(self, n: int = 8, radius: float = 0.5):
+        """IV lumen ring in the XY plane (z=0), normal ≈ [0,0,1]."""
+        angles = np.linspace(0, 2 * np.pi, n, endpoint=False)
+        coords = [(radius * float(np.cos(a)), radius * float(np.sin(a)), 0.0) for a in angles]
+        return _make_iv_pts(coords)
+
+    def test_anomalous_prox_boundary_pts_respect_overshoot(self):
+        """After clamping, all proximal boundary points must be >= overshoot from IV plane."""
+        mesh, results = self._make_anomalous_results()
+        iv_pts = self._make_iv_frame_xy()
+        overshoot = 1.0
+        # IV plane: z=0 (normal [0,0,1]), prox_centroid at origin
+        prox_centroid = (0.0, 0.0, 0.0)
+        dist_centroid = (100.0, 0.0, 0.0)  # all boundary pts go to prox
+
+        prox_pts, _, _ = _prepare_prox_dist_boundary_pts(
+            mesh, results, prox_centroid, dist_centroid,
+            proximal_is_ostium=True,
+            proximal_iv_frame_pts=iv_pts,
+            clamp_overshoot=overshoot,
+        )
+
+        # IV plane normal is [0,0,1]; correct side is z>0 after clamping.
+        # All returned proximal points must be >= overshoot from IV plane.
+        assert all(p[2] >= overshoot - 1e-6 for p in prox_pts), (
+            f"Some prox boundary points are closer than {overshoot} mm to IV plane: "
+            f"{[p[2] for p in prox_pts]}"
+        )
+
+    def test_anomalous_no_prox_point_on_wrong_side(self):
+        """No proximal boundary point must end up on the intravascular (z<0) side."""
+        mesh, results = self._make_anomalous_results()
+        iv_pts = self._make_iv_frame_xy()
+        prox_centroid = (0.0, 0.0, 0.0)
+        dist_centroid = (100.0, 0.0, 0.0)
+
+        prox_pts, _, _ = _prepare_prox_dist_boundary_pts(
+            mesh, results, prox_centroid, dist_centroid,
+            proximal_is_ostium=True,
+            proximal_iv_frame_pts=iv_pts,
+        )
+
+        assert all(p[2] >= -1e-6 for p in prox_pts)
+
+    def test_anomalous_outer_ring_pushed_radially_outward(self):
+        """After clamping, outer-ring mesh vertices are shifted radially away from IV centre."""
+        mesh, results = self._make_anomalous_results()
+        iv_pts = self._make_iv_frame_xy()
+        prox_centroid = (0.0, 0.0, 0.0)
+        dist_centroid = (100.0, 0.0, 0.0)
+
+        _, _, updated_mesh = _prepare_prox_dist_boundary_pts(
+            mesh, results, prox_centroid, dist_centroid,
+            proximal_is_ostium=True,
+            proximal_iv_frame_pts=iv_pts,
+        )
+
+        # Outer ring (indices 8-15) should be pushed radially outward.
+        # Vertices with x != 0 in the IV-plane projection are the ones that move.
+        moved = False
+        for i in range(8, 16):
+            old_r = np.linalg.norm(mesh.vertices[i, [0, 1]])   # XY radius
+            new_r = np.linalg.norm(updated_mesh.vertices[i, [0, 1]])
+            if old_r > 1e-6:  # skip vertices projecting to IV centre
+                assert new_r >= old_r - 1e-6, (
+                    f"Vertex {i} moved inward: {old_r:.4f} → {new_r:.4f}"
+                )
+                if new_r > old_r + 1e-6:
+                    moved = True
+        assert moved, "Expected at least some outer-ring vertices to move outward"
+
+    def test_non_anomalous_mesh_unchanged(self):
+        """proximal_is_ostium=False must not modify mesh vertex positions."""
+        mesh = _make_hex_fan_mesh()
+        outer = [tuple(mesh.vertices[i]) for i in range(6)]
+        results = {"boundary_points": outer}
+        prox_centroid = (1.0, 0.0, 0.0)
+        dist_centroid = (-100.0, 0.0, 0.0)
+
+        _, _, updated_mesh = _prepare_prox_dist_boundary_pts(
+            mesh, results, prox_centroid, dist_centroid, proximal_is_ostium=False
+        )
+
+        np.testing.assert_allclose(updated_mesh.vertices, mesh.vertices)

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -6,8 +6,6 @@ from multimodars import (
     PyContourPoint,
     PyContour,
     PyCenterline,
-    PyGeometry,
-    PyGeometryPair,
 )
 from multimodars._converters import (
     to_array,
@@ -156,6 +154,7 @@ def test_to_array_and_back_geometry_roundtrip():
 def test_to_array_geometry_pair():
     pytest.skip("Geometry pair conversion needs more complex setup")
 
+
 def test_numpy_to_inputdata_roundtrip():
     # Build two simple contours (frames 0 and 1)
     c0 = _make_simple_contour(0, n=2, offset=0.0)
@@ -165,8 +164,8 @@ def test_numpy_to_inputdata_roundtrip():
     lumen_arr = np.vstack([to_array(c0), to_array(c1)])
 
     # Provide an EEM only for frame 0 and a sidebranch only for frame 1
-    eem_arr = to_array(c0)           # only frame 0 present
-    sidebranch_arr = to_array(c1)    # only frame 1 present
+    eem_arr = to_array(c0)  # only frame 0 present
+    sidebranch_arr = to_array(c1)  # only frame 1 present
 
     # Empty calcification array
     calc_arr = np.zeros((0, 4))
@@ -222,4 +221,3 @@ def test_numpy_to_inputdata_roundtrip():
         assert pytest.approx(o.x) == n.x
         assert pytest.approx(o.y) == n.y
         assert pytest.approx(o.z) == n.z
-

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,13 +1,10 @@
 # tests/test_core.py
-import math
 import pytest
 from multimodars import (
     PyContourPoint,
     PyContour,
     PyGeometry,
-    PyFrame,
 )
-from conftest import _create_round_contour, _create_elliptic_contour
 
 
 # -----------------PyContourPoint---------------------------

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,6 +1,5 @@
 # tests/test_wrappers.py
 import pytest
-import numpy as np
 from multimodars import from_file_single, from_array_single
 
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have added tests that prove the fix is effective or that the feature works.
- [x] I ran `pytest` locally and all tests pass.
- [x] I updated `CHANGELOG.md` (or NEWS) and bumped the package version if applicable.
- [x] I added/updated documentation (README, docstrings, or docs).
- [ ] This PR is linked to an issue: fixes #<issue-number> (if applicable).

### What changed
Nothing changed for normal coronary arteries, however since anomalous ostium is almost 90 degrees to the aortic ostium of the coronary, had to come up with an alternative algorithm:
Made sure that doesn't break backwards compatibility since all new variables have default values.

- `clamp_overshoot` parameter in `stitch_ccta_to_intravascular` (default 0.5 mm): for anomalous
  ostia where the boundary-ring plane and the IV plane diverge by ≥ 45°, every proximal boundary
  point is projected onto the IV plane and then pushed at least `clamp_overshoot` mm away from it,
  creating an inward step that softens the stitching angle.
- `_enforce_layer_gap_from_plane`: the two mesh rings adjacent to the clamped boundary are
  pushed radially outward within the IV plane (ring 1: 0.1 mm, ring 2: 0.2 mm) to eliminate
  ridges at the clamping zone.
- Tests for `_clamp_to_plane`, `_enforce_layer_gap_from_plane`, and `_prepare_prox_dist_boundary_pts`
  with idealized geometries (`test_ccta.py`, 17 tests).

### Why this is useful
This leads to much more robust results with anomalous vessels, with only small idealization, since all assumptions are based on physiology/anatomy.

### Notes for reviewer
Pullrequest is big since before the pre-commit was not set up properly so now also all the format changes
